### PR TITLE
2097 tests setup name changes

### DIFF
--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/FeeSchedulesTestHelper.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/pricing/FeeSchedulesTestHelper.java
@@ -41,7 +41,7 @@ class FeeSchedulesTestHelper {
     protected static Map<HederaFunctionality, Map<SubType, BigDecimal>> canonicalTotalPricesInUsd = null;
 
     @BeforeAll
-    static void setup() throws IOException {
+    static void setUp() throws IOException {
         canonicalTotalPricesInUsd = assetsLoader.loadCanonicalPrices();
     }
 

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenAssociateUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenAssociateUsageTest.java
@@ -58,7 +58,7 @@ class TokenAssociateUsageTest {
     private TokenAssociateUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         base = mock(TxnUsageEstimator.class);
         given(base.get()).willReturn(A_USAGES_MATRIX);
 

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenDissociateUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenDissociateUsageTest.java
@@ -56,7 +56,7 @@ class TokenDissociateUsageTest {
     private TokenDissociateUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         base = mock(TxnUsageEstimator.class);
         given(base.get()).willReturn(A_USAGES_MATRIX);
 

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetAccountNftInfosUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetAccountNftInfosUsageTest.java
@@ -37,7 +37,7 @@ class TokenGetAccountNftInfosUsageTest {
     private List<ByteString> metadata;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         metadata = List.of(ByteString.copyFromUtf8("some metadata"));
         id = AccountID.newBuilder()
                 .setShardNum(0)

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetInfoUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetInfoUsageTest.java
@@ -42,7 +42,7 @@ class TokenGetInfoUsageTest {
     private TokenGetInfoUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = TokenGetInfoUsage.newEstimate(tokenQuery());
     }
 

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetNftInfoUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetNftInfoUsageTest.java
@@ -37,7 +37,7 @@ class TokenGetNftInfoUsageTest {
     private TokenGetNftInfoUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = TokenGetNftInfoUsage.newEstimate(query());
     }
 

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetNftInfosUsageTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/usage/token/TokenGetNftInfosUsageTest.java
@@ -37,7 +37,7 @@ class TokenGetNftInfosUsageTest {
     private List<ByteString> metadata;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         metadata = List.of(ByteString.copyFromUtf8("some metadata"));
         id = TokenID.newBuilder().setShardNum(0).setRealmNum(0).setTokenNum(1).build();
         subject = TokenGetNftInfosUsage.newEstimate(tokenNftInfosQuery());

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/GasLimitDeterministicThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/GasLimitDeterministicThrottleTest.java
@@ -33,7 +33,7 @@ class GasLimitDeterministicThrottleTest {
     GasLimitDeterministicThrottle subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new GasLimitDeterministicThrottle(DEFAULT_CAPACITY);
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ExchangeRateManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ExchangeRateManagerTest.java
@@ -63,7 +63,7 @@ class ExchangeRateManagerTest {
     ExchangeRateManager subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         final ConfigProvider configProvider = () -> new VersionedConfigImpl(HederaTestConfigBuilder.createConfig(), 1);
         subject = new ExchangeRateManager(configProvider);
         final var state = new FakeHederaState();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/DefaultKeyVerifierTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/DefaultKeyVerifierTest.java
@@ -229,7 +229,7 @@ class DefaultKeyVerifierTest {
         private static final Key ED25519_X2 = FAKE_ED25519_KEY_INFOS[2].publicKey();
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             when(verificationAssistant.test(any(), any())).thenAnswer(invocation -> {
                 final SignatureVerification verification = invocation.getArgument(1);
                 return verification.passed();
@@ -751,7 +751,7 @@ class DefaultKeyVerifierTest {
     final class FindingSignatureVerificationWithCompoundKeyTests {
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             lenient().when(verificationAssistant.test(any(), any())).thenAnswer(invocation -> {
                 final SignatureVerification verification = invocation.getArgument(1);
                 return verification.passed();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/DelegateKeyVerifierTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/DelegateKeyVerifierTest.java
@@ -62,7 +62,7 @@ class DelegateKeyVerifierTest {
     }
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new DelegateKeyVerifier(parentCallback);
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/SolvencyPreCheckTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/SolvencyPreCheckTest.java
@@ -84,7 +84,7 @@ class SolvencyPreCheckTest extends AppTestBase {
     private SolvencyPreCheck subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         when(authorizer.hasPrivilegedAuthorization(any(), any(), any())).thenReturn(SystemPrivilege.UNNECESSARY);
 
         subject = new SolvencyPreCheck(exchangeRateManager, feeManager, expiryValidation, authorizer);
@@ -110,7 +110,7 @@ class SolvencyPreCheckTest extends AppTestBase {
         private ReadableStoreFactory storeFactory;
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             setupStandardStates();
             storeFactory = new ReadableStoreFactory(state);
         }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
@@ -156,7 +156,7 @@ final class TransactionCheckerTest extends AppTestBase {
      * sure it does so correctly!
      */
     @BeforeEach
-    void setup() {
+    void setUp() {
         txBody = bodyBuilder(txIdBuilder()).build();
         signatureMap = sigMapBuilder().build();
         signedTx = signedTxBuilder(txBody, signatureMap).build();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleContextImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleContextImplTest.java
@@ -181,7 +181,7 @@ class HandleContextImplTest extends StateTestBase implements Scenarios {
     private SelfNodeInfo selfNodeInfo;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         when(serviceScopeLookup.getServiceName(any())).thenReturn(TokenService.NAME);
     }
 
@@ -522,7 +522,7 @@ class HandleContextImplTest extends StateTestBase implements Scenarios {
         private HandleContext context;
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             when(stack.createReadableStates(TokenService.NAME)).thenReturn(defaultTokenReadableStates());
             when(stack.createWritableStates(TokenService.NAME))
                     .thenReturn(MapWritableStates.builder()
@@ -599,7 +599,7 @@ class HandleContextImplTest extends StateTestBase implements Scenarios {
         private HandleContext context;
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             when(stack.createReadableStates(TokenService.NAME)).thenReturn(defaultTokenReadableStates());
             when(stack.createWritableStates(TokenService.NAME))
                     .thenReturn(MapWritableStates.builder()
@@ -624,7 +624,7 @@ class HandleContextImplTest extends StateTestBase implements Scenarios {
         private HandleContext context;
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             when(stack.createReadableStates(TokenService.NAME)).thenReturn(defaultTokenReadableStates());
             when(stack.createWritableStates(TokenService.NAME))
                     .thenReturn(MapWritableStates.builder()
@@ -656,7 +656,7 @@ class HandleContextImplTest extends StateTestBase implements Scenarios {
         private HandleContext context;
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             when(stack.createReadableStates(TokenService.NAME)).thenReturn(defaultTokenReadableStates());
             when(stack.createWritableStates(TokenService.NAME))
                     .thenReturn(MapWritableStates.builder()
@@ -679,7 +679,7 @@ class HandleContextImplTest extends StateTestBase implements Scenarios {
     final class RecordBuilderTest {
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             when(stack.createWritableStates(TokenService.NAME))
                     .thenReturn(MapWritableStates.builder()
                             .state(MapWritableKVState.builder("ACCOUNTS").build())
@@ -768,7 +768,7 @@ class HandleContextImplTest extends StateTestBase implements Scenarios {
         private SavepointStackImpl stack;
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             final var baseKVState = new MapWritableKVState<>(FRUIT_STATE_KEY, new HashMap<>(BASE_DATA));
             final var writableStates =
                     MapWritableStates.builder().state(baseKVState).build();
@@ -1167,7 +1167,7 @@ class HandleContextImplTest extends StateTestBase implements Scenarios {
         private HandleContext context;
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             when(stack.createWritableStates(TokenService.NAME))
                     .thenReturn(MapWritableStates.builder()
                             .state(MapWritableKVState.builder("ACCOUNTS").build())

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
@@ -217,7 +217,7 @@ class HandleWorkflowTest extends AppTestBase {
     private HandleWorkflow workflow;
 
     @BeforeEach
-    void setup() throws PreCheckException {
+    void setUp() throws PreCheckException {
         setupStandardStates();
 
         accountsState.put(
@@ -793,7 +793,7 @@ class HandleWorkflowTest extends AppTestBase {
     final class FullPreHandleRunTest {
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             when(preHandleWorkflow.preHandleTransaction(any(), any(), any(), eq(platformTxn)))
                     .thenReturn(OK_RESULT);
         }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/GenesisRecordsConsensusHookTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/GenesisRecordsConsensusHookTest.java
@@ -75,7 +75,7 @@ class GenesisRecordsConsensusHookTest {
     private GenesisRecordsConsensusHook subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         given(context.readableStore(ReadableBlockRecordStore.class)).willReturn(blockStore);
         given(context.consensusTime()).willReturn(CONSENSUS_NOW);
         given(context.addUncheckedPrecedingChildRecordBuilder(GenesisAccountRecordBuilder.class))

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImplTest.java
@@ -58,7 +58,7 @@ class SavepointStackImplTest extends StateTestBase {
     private HederaState baseState;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         final var baseKVState = new MapWritableKVState<>(FRUIT_STATE_KEY, new HashMap<>(BASE_DATA));
         final var writableStates =
                 MapWritableStates.builder().state(baseKVState).build();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
@@ -113,7 +113,7 @@ class IngestWorkflowImplTest extends AppTestBase {
     private VersionedConfiguration configuration;
 
     @BeforeEach
-    void setup() throws PreCheckException {
+    void setUp() throws PreCheckException {
         // The request buffer, with basically random bytes
         requestBuffer = randomBytes(10);
         transactionBody = TransactionBody.newBuilder()

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
@@ -105,7 +105,7 @@ final class SubmissionManagerTest extends AppTestBase {
         private TransactionBody txBody;
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             bytes = randomBytes(25);
             when(mockedMetrics.getOrCreate(any())).thenReturn(platformTxnRejections);
             submissionManager = new SubmissionManager(platform, deduplicationCache, config, mockedMetrics);
@@ -198,7 +198,7 @@ final class SubmissionManagerTest extends AppTestBase {
         private byte[] uncheckedBytes;
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             config = () -> new VersionedConfigImpl(
                     HederaTestConfigBuilder.create()
                             .withValue("hedera.profiles.active", Profile.TEST.toString())

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImplTest.java
@@ -92,7 +92,7 @@ class PreHandleContextImplTest implements Scenarios {
     private PreHandleContextImpl subject;
 
     @BeforeEach
-    void setup() throws PreCheckException {
+    void setUp() throws PreCheckException {
         given(storeFactory.getStore(ReadableAccountStore.class)).willReturn(accountStore);
         given(accountStore.getAccountById(PAYER)).willReturn(account);
         given(account.key()).willReturn(payerKey);
@@ -131,7 +131,7 @@ class PreHandleContextImplTest implements Scenarios {
     final class KeyRequestTest {
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             given(accountStore.getAccountById(ERIN.accountID())).willReturn(ERIN.account());
         }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryCheckerTest.java
@@ -91,7 +91,7 @@ class QueryCheckerTest extends AppTestBase {
     private QueryChecker checker;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         checker = new QueryChecker(authorizer, cryptoTransferHandler, solvencyPreCheck, expiryValidation, feeManager);
     }
 
@@ -216,7 +216,7 @@ class QueryCheckerTest extends AppTestBase {
         private ReadableAccountStore store;
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             setupStandardStates();
 
             final var storeFactory = new ReadableStoreFactory(state);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryDispatcherTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryDispatcherTest.java
@@ -164,7 +164,7 @@ class QueryDispatcherTest {
     private QueryDispatcher dispatcher;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         handlers = new QueryHandlers(
                 consensusGetTopicInfoHandler,
                 contractGetBySolidityIDHandler,

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessorTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessorTest.java
@@ -97,7 +97,7 @@ class HederaEvmMessageCallProcessorTest {
     private AbstractLedgerEvmWorldUpdater updater;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaEvmMessageCallProcessor(
                 evm, precompiles, Map.of(HEDERA_PRECOMPILE_ADDRESS_STRING, nonHtsPrecompile));
 

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessorV038Test.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmMessageCallProcessorV038Test.java
@@ -99,7 +99,7 @@ class HederaEvmMessageCallProcessorV038Test {
     private AbstractLedgerEvmWorldUpdater updater;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaEvmMessageCallProcessorV038(
                 evm, precompiles, Map.of(HEDERA_PRECOMPILE_ADDRESS_STRING, nonHtsPrecompile), address -> false);
 

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessorTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessorTest.java
@@ -110,7 +110,7 @@ class HederaEvmTxProcessorTest {
     private String ccpVersion;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         final var operationRegistry = new OperationRegistry();
         MainnetEVMs.registerLondonOperations(operationRegistry, gasCalculator, BigInteger.ZERO);
         operations.forEach(operationRegistry::put);

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaDelegateCallOperationTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaDelegateCallOperationTest.java
@@ -87,7 +87,7 @@ class HederaDelegateCallOperationTest {
     private HederaDelegateCallOperation subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaDelegateCallOperation(calc, addressValidator);
         given(evmMsgFrame.getWorldUpdater()).willReturn(worldUpdater);
         given(worldUpdater.get(any())).willReturn(acc);

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaDelegateCallOperationV038Test.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaDelegateCallOperationV038Test.java
@@ -65,7 +65,7 @@ class HederaDelegateCallOperationV038Test {
     private HederaDelegateCallOperationV038 subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaDelegateCallOperationV038(calc, addressValidator, a -> false);
         given(evmMsgFrame.getWorldUpdater()).willReturn(worldUpdater);
         given(worldUpdater.get(any())).willReturn(acc);

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmCreate2OperationTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmCreate2OperationTest.java
@@ -62,7 +62,7 @@ class HederaEvmCreate2OperationTest {
     private CreateOperationExternalizer externalizer;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaEvmCreate2Operation(gasCalculator, evmProperties, externalizer);
     }
 

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmCreateOperationTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/contracts/operations/HederaEvmCreateOperationTest.java
@@ -55,7 +55,7 @@ class HederaEvmCreateOperationTest {
     private CreateOperationExternalizer externalizer;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaEvmCreateOperation(gasCalculator, externalizer);
     }
 

--- a/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/AbstractCodeCacheTest.java
+++ b/hedera-node/hedera-evm/src/test/java/com/hedera/node/app/service/evm/store/contracts/AbstractCodeCacheTest.java
@@ -45,7 +45,7 @@ class AbstractCodeCacheTest {
     MockAbstractCodeCache codeCache;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         codeCache = new MockAbstractCodeCache(100, entityAccess);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/AccountNumbersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/AccountNumbersTest.java
@@ -42,7 +42,7 @@ class AccountNumbersTest {
     AccountNumbers subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         properties = mock(PropertySource.class);
         given(properties.getLongProperty(ACCOUNTS_ADDRESS_BOOK_ADMIN)).willReturn(55L);
         given(properties.getLongProperty(ACCOUNTS_FEE_SCHEDULE_ADMIN)).willReturn(56L);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/EntityNumbersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/EntityNumbersTest.java
@@ -36,7 +36,7 @@ class EntityNumbersTest {
     EntityNumbers subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         fileNumbers = new MockFileNumbers();
         hederaNumbers = new MockHederaNumbers();
         accountNumbers = new MockAccountNumbers();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/FileNumbersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/FileNumbersTest.java
@@ -45,7 +45,7 @@ class FileNumbersTest {
     FileNumbers subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         properties = mock(PropertySource.class);
         hederaNumbers = mock(HederaNumbers.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/HederaNumbersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/config/HederaNumbersTest.java
@@ -32,7 +32,7 @@ class HederaNumbersTest {
     HederaNumbers subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         properties = mock(PropertySource.class);
         given(properties.getLongProperty(HEDERA_SHARD)).willReturn(1L);
         given(properties.getLongProperty(HEDERA_REALM)).willReturn(2L);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/BasicTransactionContextTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/BasicTransactionContextTest.java
@@ -196,7 +196,7 @@ class BasicTransactionContextTest {
     private BasicTransactionContext subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new BasicTransactionContext(
                 narratedCharging,
                 () -> AccountStorageAdapter.fromInMemory(MerkleMapLike.from(accounts)),

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/trackers/ConsensusStatusCountsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/trackers/ConsensusStatusCountsTest.java
@@ -38,7 +38,7 @@ class ConsensusStatusCountsTest {
     ConsensusStatusCounts subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ConsensusStatusCounts(new ObjectMapper());
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/trackers/IssEventInfoTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/domain/trackers/IssEventInfoTest.java
@@ -44,7 +44,7 @@ class IssEventInfoTest {
     private IssEventInfo subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new IssEventInfo(nodeLocalProperties);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/StateViewTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/primitives/StateViewTest.java
@@ -230,7 +230,7 @@ class StateViewTest {
 
     @BeforeEach
     @SuppressWarnings("unchecked")
-    public void setup() throws Throwable {
+    public void setUp() throws Throwable {
         metadata = new HFileMeta(false, TxnHandlingScenario.MISC_FILE_WACL_KT.asJKey(), expiry, fileMemo);
         immutableMetadata = new HFileMeta(false, StateView.EMPTY_WACL, expiry);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/ChainedSourcesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/ChainedSourcesTest.java
@@ -41,7 +41,7 @@ class ChainedSourcesTest {
     ChainedSources subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         first = mock(PropertySource.class);
         given(first.containsProperty(firstName)).willReturn(true);
         given(first.getProperty(firstName)).willReturn(firstValue);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/GlobalDynamicPropertiesTest.java
@@ -196,7 +196,7 @@ class GlobalDynamicPropertiesTest {
     private GlobalDynamicProperties subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         numbers = mock(HederaNumbers.class);
         given(numbers.shard()).willReturn(1L);
         given(numbers.realm()).willReturn(2L);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/NodeLocalPropertiesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/NodeLocalPropertiesTest.java
@@ -78,7 +78,7 @@ class NodeLocalPropertiesTest {
     private static final Profile[] LEGACY_ENV_ORDER = {DEV, PROD, TEST};
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         properties = mock(PropertySource.class);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/ScreenedNodeFilePropsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/ScreenedNodeFilePropsTest.java
@@ -51,7 +51,7 @@ class ScreenedNodeFilePropsTest {
             entry(HEDERA_PROFILES_ACTIVE, Profile.TEST));
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         log = mock(Logger.class);
         ScreenedNodeFileProps.log = log;
         ScreenedNodeFileProps.nodePropsLoc = STD_NODE_PROPS_LOC;

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/ScreenedSysFilePropsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/ScreenedSysFilePropsTest.java
@@ -59,7 +59,7 @@ class ScreenedSysFilePropsTest {
     private ScreenedSysFileProps subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ScreenedSysFileProps();
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/StandardizedPropertySourcesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/context/properties/StandardizedPropertySourcesTest.java
@@ -57,7 +57,7 @@ class StandardizedPropertySourcesTest {
     private StandardizedPropertySources subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new StandardizedPropertySources(bootstrapProps, dynamicGlobalProps, nodeProps);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallEvmTxProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallEvmTxProcessorTest.java
@@ -153,7 +153,7 @@ class CallEvmTxProcessorTest {
     private String ccpVersion;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         CommonProcessorSetup.setup(gasCalculator);
         var operationRegistry = new OperationRegistry();
         MainnetEVMs.registerLondonOperations(operationRegistry, gasCalculator, BigInteger.ZERO);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalEvmTxProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalEvmTxProcessorTest.java
@@ -112,7 +112,7 @@ class CallLocalEvmTxProcessorTest {
     private CallLocalEvmTxProcessor callLocalEvmTxProcessor;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         CommonProcessorSetup.setup(gasCalculator);
 
         var operationRegistry = new OperationRegistry();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalExecutorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CallLocalExecutorTest.java
@@ -82,7 +82,7 @@ class CallLocalExecutorTest {
     private EntityAccess entityAccess;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         query = localCallQuery(contractID.asGrpcContract(), ANSWER_ONLY);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CreateEvmTxProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/CreateEvmTxProcessorTest.java
@@ -116,7 +116,7 @@ class CreateEvmTxProcessorTest {
     private final long GAS_LIMIT = 300_000L;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         CommonProcessorSetup.setup(gasCalculator);
 
         var operationRegistry = new OperationRegistry();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorTest.java
@@ -140,7 +140,7 @@ class HederaMessageCallProcessorTest {
     private InfrastructureFactory infrastructureFactory;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaMessageCallProcessor(
                 evm,
                 precompiles,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorV038Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/execution/HederaMessageCallProcessorV038Test.java
@@ -142,7 +142,7 @@ class HederaMessageCallProcessorV038Test {
     private InfrastructureFactory infrastructureFactory;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaMessageCallProcessorV038(
                 evm,
                 precompiles,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV18Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/gascalculator/GasCalculatorHederaV18Test.java
@@ -83,7 +83,7 @@ class GasCalculatorHederaV18Test {
     private GasCalculatorHederaV18 gasCalculatorHedera;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         gasCalculatorHedera = new GasCalculatorHederaV18(properties, usagePricesProvider, hbarCentExchange);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallCodeOperationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallCodeOperationTest.java
@@ -97,7 +97,7 @@ class HederaCallCodeOperationTest {
     private HederaCallCodeOperation subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaCallCodeOperation(sigsVerifier, calc, addressValidator, precompiledContractMap);
         commonSetup(evmMsgFrame, worldUpdater, acc);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallCodeOperationV038Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallCodeOperationV038Test.java
@@ -77,7 +77,7 @@ class HederaCallCodeOperationV038Test {
     private HederaCallCodeOperationV038 subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaCallCodeOperationV038(sigsVerifier, calc, addressValidator, systemAccountDetector);
         commonSetup(evmMsgFrame, worldUpdater, acc);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationTest.java
@@ -77,7 +77,7 @@ class HederaCallOperationTest {
     private HederaCallOperation subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaCallOperation(sigsVerifier, calc, addressValidator, precompiledContractMap);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV034Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV034Test.java
@@ -88,7 +88,7 @@ class HederaCallOperationV034Test {
     private HederaCallOperationV034 subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaCallOperationV034(
                 sigsVerifier, calc, addressValidator, precompiledContractMap, globalDynamicProperties);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV038Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaCallOperationV038Test.java
@@ -88,7 +88,7 @@ class HederaCallOperationV038Test {
     private HederaCallOperationV038 subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaCallOperationV038(
                 sigsVerifier, calc, addressValidator, systemAccountDetector, globalDynamicProperties);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaStaticCallOperationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaStaticCallOperationTest.java
@@ -93,7 +93,7 @@ class HederaStaticCallOperationTest {
     private HederaStaticCallOperation subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaStaticCallOperation(calc, addressValidator, precompiledContractMap);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaStaticCallOperationV038Test.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/operation/HederaStaticCallOperationV038Test.java
@@ -68,7 +68,7 @@ class HederaStaticCallOperationV038Test {
     private HederaStaticCallOperationV038 subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new HederaStaticCallOperationV038(calc, addressValidator, systemAccountDetector);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/sources/TxnAwareEvmSigsVerifierTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/contracts/sources/TxnAwareEvmSigsVerifierTest.java
@@ -158,7 +158,7 @@ class TxnAwareEvmSigsVerifierTest {
     private TxnAwareEvmSigsVerifier subject;
 
     @BeforeEach
-    void setup() throws Exception {
+    void setUp() throws Exception {
         expectedKey = TxnHandlingScenario.MISC_ACCOUNT_KT.asJKey();
 
         subject = new TxnAwareEvmSigsVerifier(activationTest, txnCtx, cryptoValidity, dynamicProperties);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/StandardExemptionsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/StandardExemptionsTest.java
@@ -38,7 +38,7 @@ class StandardExemptionsTest {
     StandardExemptions subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         policies = mock(SystemOpPolicies.class);
         accessor = mock(SignedTxnAccessor.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/BasicFcfsUsagePricesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/BasicFcfsUsagePricesTest.java
@@ -119,7 +119,7 @@ class BasicFcfsUsagePricesTest {
     PlatformTxnAccessor accessor;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         nextFeeSchedule = FeeSchedule.newBuilder()
                 .setExpiryTime(TimestampSeconds.newBuilder().setSeconds(nextExpiry))
                 .addTransactionFeeSchedule(TransactionFeeSchedule.newBuilder()

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/UsageBasedFeeCalculatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/UsageBasedFeeCalculatorTest.java
@@ -151,7 +151,7 @@ class UsageBasedFeeCalculatorTest {
     private UsageBasedFeeCalculator subject;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         view = mock(StateView.class);
         query = mock(Query.class);
         payerKey = complexKey.asJKey();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/queries/GetMerkleTopicInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/queries/GetMerkleTopicInfoResourceUsageTest.java
@@ -57,7 +57,7 @@ class GetMerkleTopicInfoResourceUsageTest {
     private GetTopicInfoResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         topics = mock(MerkleMap.class);
         final var children = new MutableStateChildren();
         children.setTopics(MerkleMapLike.from(topics));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/CreateMerkleTopicResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/CreateMerkleTopicResourceUsageTest.java
@@ -38,7 +38,7 @@ class CreateMerkleTopicResourceUsageTest extends TopicResourceUsageTestBase {
     private CreateTopicResourceUsage subject;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         super.setup();
         subject = new CreateTopicResourceUsage();
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/DeleteMerkleTopicResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/DeleteMerkleTopicResourceUsageTest.java
@@ -29,7 +29,7 @@ class DeleteMerkleTopicResourceUsageTest extends TopicResourceUsageTestBase {
     private DeleteTopicResourceUsage subject;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         super.setup();
         subject = new DeleteTopicResourceUsage();
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/UpdateMerkleTopicResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/consensus/txns/UpdateMerkleTopicResourceUsageTest.java
@@ -77,7 +77,7 @@ class UpdateMerkleTopicResourceUsageTest extends TopicResourceUsageTestBase {
     private static final String defaultMemo = "12345678";
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         super.setup();
         subject = new UpdateTopicResourceUsage();
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/ContractCallLocalResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/ContractCallLocalResourceUsageTest.java
@@ -123,7 +123,7 @@ class ContractCallLocalResourceUsageTest {
     private ContractCallLocalResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ContractCallLocalResourceUsage(
                 usageEstimator,
                 properties,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetBytecodeResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetBytecodeResourceUsageTest.java
@@ -50,7 +50,7 @@ class GetBytecodeResourceUsageTest {
     private GetBytecodeResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         aliasManager = mock(AliasManager.class);
         usageEstimator = mock(SmartContractFeeBuilder.class);
         view = mock(StateView.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetContractInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/queries/GetContractInfoResourceUsageTest.java
@@ -82,7 +82,7 @@ class GetContractInfoResourceUsageTest {
     private GetContractInfoResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         expected = mock(FeeData.class);
         aliasManager = mock(AliasManager.class);
         dynamicProperties = mock(GlobalDynamicProperties.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractCallResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractCallResourceUsageTest.java
@@ -37,7 +37,7 @@ class ContractCallResourceUsageTest {
     private TransactionBody contractCallTxn;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         contractCallTxn = mock(TransactionBody.class);
         given(contractCallTxn.hasContractCall()).willReturn(true);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractCreateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractCreateResourceUsageTest.java
@@ -37,7 +37,7 @@ class ContractCreateResourceUsageTest {
     private TransactionBody contractCreateTxn;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         contractCreateTxn = mock(TransactionBody.class);
         given(contractCreateTxn.hasContractCreateInstance()).willReturn(true);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractDeleteResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractDeleteResourceUsageTest.java
@@ -37,7 +37,7 @@ class ContractDeleteResourceUsageTest {
     private TransactionBody contractDeleteTxn;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         contractDeleteTxn = mock(TransactionBody.class);
         given(contractDeleteTxn.hasContractDeleteInstance()).willReturn(true);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractUpdateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/contract/txns/ContractUpdateResourceUsageTest.java
@@ -56,7 +56,7 @@ class ContractUpdateResourceUsageTest {
     private TransactionBody contractUpdateTxn;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         contractUpdateTxn = mock(TransactionBody.class);
         final ContractUpdateTransactionBody update = mock(ContractUpdateTransactionBody.class);
         given(update.getContractID()).willReturn(target);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountDetailsResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountDetailsResourceUsageTest.java
@@ -106,7 +106,7 @@ class GetAccountDetailsResourceUsageTest {
             .build();
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new GetAccountDetailsResourceUsage(cryptoOpsUsage, aliasManager, dynamicProperties);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountInfoResourceUsageTest.java
@@ -94,7 +94,7 @@ class GetAccountInfoResourceUsageTest {
     private GetAccountInfoResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new GetAccountInfoResourceUsage(cryptoOpsUsage, aliasManager, dynamicProperties, rewardCalculator);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountRecordsResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetAccountRecordsResourceUsageTest.java
@@ -78,7 +78,7 @@ class GetAccountRecordsResourceUsageTest {
     private GetAccountRecordsResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         aValue = MerkleAccountFactory.newAccount().get();
         aValue.records().offer(recordOne());
         aValue.records().offer(recordTwo());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetTxnRecordResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/queries/GetTxnRecordResourceUsageTest.java
@@ -79,7 +79,7 @@ class GetTxnRecordResourceUsageTest {
     private AnswerFunctions answerFunctions;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         desiredRecord = mock(TransactionRecord.class);
 
         usageEstimator = mock(CryptoFeeBuilder.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/txns/CryptoDeleteResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/crypto/txns/CryptoDeleteResourceUsageTest.java
@@ -37,7 +37,7 @@ class CryptoDeleteResourceUsageTest {
     private TransactionBody cryptoDeleteTxn;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         cryptoDeleteTxn = mock(TransactionBody.class);
         given(cryptoDeleteTxn.hasCryptoDelete()).willReturn(true);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/ethereum/txns/ContractCallResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/ethereum/txns/ContractCallResourceUsageTest.java
@@ -37,7 +37,7 @@ class EthereumTransactionResourceUsageTest {
     private TransactionBody ethTxn;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         ethTxn = mock(TransactionBody.class);
         given(ethTxn.hasEthereumTransaction()).willReturn(true);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/queries/GetFileContentsResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/queries/GetFileContentsResourceUsageTest.java
@@ -54,7 +54,7 @@ class GetFileContentsResourceUsageTest {
             .build();
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         usageEstimator = mock(FileFeeBuilder.class);
         view = mock(StateView.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/queries/GetFileInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/queries/GetFileInfoResourceUsageTest.java
@@ -66,7 +66,7 @@ class GetFileInfoResourceUsageTest {
     private GetFileInfoResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         fileOpsUsage = mock(FileOpsUsage.class);
         view = mock(StateView.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileCreateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileCreateResourceUsageTest.java
@@ -39,7 +39,7 @@ class FileCreateResourceUsageTest {
     private TransactionBody fileCreateTxn;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         fileCreateTxn = mock(TransactionBody.class);
         given(fileCreateTxn.hasFileCreate()).willReturn(true);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileDeleteResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileDeleteResourceUsageTest.java
@@ -37,7 +37,7 @@ class FileDeleteResourceUsageTest {
     private TransactionBody fileDeleteTxn;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         fileDeleteTxn = mock(TransactionBody.class);
         given(fileDeleteTxn.hasFileDelete()).willReturn(true);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileUpdateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/FileUpdateResourceUsageTest.java
@@ -70,7 +70,7 @@ class FileUpdateResourceUsageTest {
     private TransactionBody fileUpdateTxn;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         fileOpsUsage = mock(FileOpsUsage.class);
 
         view = mock(StateView.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/SystemDeleteFileResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/SystemDeleteFileResourceUsageTest.java
@@ -37,7 +37,7 @@ class SystemDeleteFileResourceUsageTest {
     private TransactionBody systemDeleteFileTxn;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         systemDeleteFileTxn = mock(TransactionBody.class);
         given(systemDeleteFileTxn.hasSystemDelete()).willReturn(true);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/SystemUndeleteFileResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/file/txns/SystemUndeleteFileResourceUsageTest.java
@@ -37,7 +37,7 @@ class SystemUndeleteFileResourceUsageTest {
     private TransactionBody systemUndeleteFileTxn;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         systemUndeleteFileTxn = mock(TransactionBody.class);
         given(systemUndeleteFileTxn.hasSystemUndelete()).willReturn(true);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetAccountDetailsResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetAccountDetailsResourceUsageTest.java
@@ -107,7 +107,7 @@ class GetAccountDetailsResourceUsageTest {
     private GetAccountDetailsResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new GetAccountDetailsResourceUsage(cryptoOpsUsage, aliasManager, dynamicProperties);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetExecTimeResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetExecTimeResourceUsageTest.java
@@ -46,7 +46,7 @@ class GetExecTimeResourceUsageTest {
     private GetExecTimeResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new GetExecTimeResourceUsage();
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetVersionInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/meta/queries/GetVersionInfoResourceUsageTest.java
@@ -35,7 +35,7 @@ class GetVersionInfoResourceUsageTest {
     private GetVersionInfoResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new GetVersionInfoResourceUsage();
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/queries/GetScheduleInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/queries/GetScheduleInfoResourceUsageTest.java
@@ -77,7 +77,7 @@ class GetScheduleInfoResourceUsageTest {
     private GetScheduleInfoResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         view = mock(StateView.class);
         given(view.infoForSchedule(target)).willReturn(Optional.of(info));
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleCreateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleCreateResourceUsageTest.java
@@ -51,7 +51,7 @@ class ScheduleCreateResourceUsageTest {
     FeeData expected;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         expected = mock(FeeData.class);
         view = mock(StateView.class);
         scheduleCreateTxn = mock(TransactionBody.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleDeleteResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleDeleteResourceUsageTest.java
@@ -67,7 +67,7 @@ class ScheduleDeleteResourceUsageTest {
             .build();
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         expected = mock(FeeData.class);
         view = mock(StateView.class);
         scheduleDeleteTxn = mock(TransactionBody.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleSignResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/schedule/txns/ScheduleSignResourceUsageTest.java
@@ -65,7 +65,7 @@ class ScheduleSignResourceUsageTest {
             .build();
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         expected = mock(FeeData.class);
         view = mock(StateView.class);
         scheduleSignTxn = mock(TransactionBody.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/system/txns/FreezeResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/system/txns/FreezeResourceUsageTest.java
@@ -33,7 +33,7 @@ class FreezeResourceUsageTest {
     private FreezeResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new FreezeResourceUsage();
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/system/txns/UncheckedSubmitResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/system/txns/UncheckedSubmitResourceUsageTest.java
@@ -33,7 +33,7 @@ class UncheckedSubmitResourceUsageTest {
     private UncheckedSubmitResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new UncheckedSubmitResourceUsage();
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenInfoResourceUsageTest.java
@@ -77,7 +77,7 @@ class GetTokenInfoResourceUsageTest {
     private GetTokenInfoResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         expected = mock(FeeData.class);
         view = mock(StateView.class);
         estimator = mock(TokenGetInfoUsage.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenNftInfoResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/queries/GetTokenNftInfoResourceUsageTest.java
@@ -68,7 +68,7 @@ class GetTokenNftInfoResourceUsageTest {
     private GetTokenNftInfoResourceUsage subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         expected = mock(FeeData.class);
         view = mock(StateView.class);
         estimator = mock(TokenGetNftInfoUsage.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenAssociateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenAssociateResourceUsageTest.java
@@ -68,7 +68,7 @@ class TokenAssociateResourceUsageTest {
     private TxnUsageEstimator txnUsageEstimator;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         expected = mock(FeeData.class);
 
         account = mock(MerkleAccount.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenCreateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenCreateResourceUsageTest.java
@@ -61,7 +61,7 @@ class TokenCreateResourceUsageTest {
     TxnUsageEstimator txnUsageEstimator;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         expected = mock(FeeData.class);
         view = mock(StateView.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDeleteResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDeleteResourceUsageTest.java
@@ -51,7 +51,7 @@ class TokenDeleteResourceUsageTest {
     TxnUsageEstimator txnUsageEstimator;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         expected = mock(FeeData.class);
         view = mock(StateView.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDissociateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenDissociateResourceUsageTest.java
@@ -68,7 +68,7 @@ class TokenDissociateResourceUsageTest {
     TxnUsageEstimator txnUsageEstimator;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         expected = mock(FeeData.class);
         account = mock(MerkleAccount.class);
         given(account.getExpiry()).willReturn(expiry);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenGrantKycResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenGrantKycResourceUsageTest.java
@@ -51,7 +51,7 @@ class TokenGrantKycResourceUsageTest {
     TxnUsageEstimator txnUsageEstimator;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         expected = mock(FeeData.class);
         view = mock(StateView.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenRevokeKycResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenRevokeKycResourceUsageTest.java
@@ -53,7 +53,7 @@ class TokenRevokeKycResourceUsageTest {
     TxnUsageEstimator txnUsageEstimator;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         expected = mock(FeeData.class);
         view = mock(StateView.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenUpdateResourceUsageTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/fees/calculation/token/txns/TokenUpdateResourceUsageTest.java
@@ -80,7 +80,7 @@ class TokenUpdateResourceUsageTest {
     TxnUsageEstimator txnUsageEstimator;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         expected = mock(FeeData.class);
         view = mock(StateView.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/TieredHederaFsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/TieredHederaFsTest.java
@@ -83,7 +83,7 @@ class TieredHederaFsTest {
     private TieredHederaFs subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         deadAttr = new HFileMeta(false, validKey, now.getEpochSecond() - 1);
         livingAttr = new HFileMeta(false, validKey, now.getEpochSecond() + lifetimeSecs);
         deletedAttr = new HFileMeta(true, validKey, now.getEpochSecond() + lifetimeSecs);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/FeeSchedulesManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/FeeSchedulesManagerTest.java
@@ -59,7 +59,7 @@ class FeeSchedulesManagerTest {
     }
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         attr = new HFileMeta(false, new JContractIDKey(1, 2, 3), Instant.now().getEpochSecond());
 
         fees = mock(FeeCalculator.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/TxnAwareRatesManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/TxnAwareRatesManagerTest.java
@@ -82,7 +82,7 @@ class TxnAwareRatesManagerTest {
     TxnAwareRatesManager subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         attr = new HFileMeta(false, new JContractIDKey(1, 2, 3), Instant.now().getEpochSecond());
 
         final PlatformTxnAccessor accessor = mock(PlatformTxnAccessor.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/ValidatingCallbackInterceptorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/interceptors/ValidatingCallbackInterceptorTest.java
@@ -53,7 +53,7 @@ class ValidatingCallbackInterceptorTest {
     ValidatingCallbackInterceptor subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         attr = new HFileMeta(false, new JContractIDKey(1, 2, 3), Instant.now().getEpochSecond());
 
         validator = mock(Predicate.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/store/BytesStoreAdapterTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/store/BytesStoreAdapterTest.java
@@ -49,7 +49,7 @@ class BytesStoreAdapterTest {
     BytesStoreAdapter<Integer, StringBuilder> subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         delegate = new HashMap<>();
         delegate.put(fromInteger.apply(0), bytes("ALREADY HERE"));
         subject = new BytesStoreAdapter<>(Integer.class, toSb, fromSb, toInteger, fromInteger, delegate);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/store/FcBlobsBytesStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/files/store/FcBlobsBytesStoreTest.java
@@ -50,7 +50,7 @@ class FcBlobsBytesStoreTest {
     private FcBlobsBytesStore subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         pathedBlobs = mock(VirtualMap.class);
 
         givenMockBlobs();

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/ConfigDrivenNettyFactoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/ConfigDrivenNettyFactoryTest.java
@@ -50,7 +50,7 @@ class ConfigDrivenNettyFactoryTest {
     ConfigDrivenNettyFactory subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ConfigDrivenNettyFactory(nodeLocalProperties);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/NettyGrpcServerManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/NettyGrpcServerManagerTest.java
@@ -62,7 +62,7 @@ class NettyGrpcServerManagerTest {
     private NettyGrpcServerManager subject;
 
     @BeforeEach
-    void setup() throws Exception {
+    void setUp() throws Exception {
         server = mock(Server.class);
         tlsServer = mock(Server.class);
         a = mock(BindableService.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/ConsensusControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/ConsensusControllerTest.java
@@ -47,7 +47,7 @@ class ConsensusControllerTest {
     ConsensusController subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         txnObserver = mock(StreamObserver.class);
         queryObserver = mock(StreamObserver.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/ContractControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/ContractControllerTest.java
@@ -54,7 +54,7 @@ class ContractControllerTest {
     ContractController subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         txnObserver = mock(StreamObserver.class);
         queryObserver = mock(StreamObserver.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/CryptoControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/CryptoControllerTest.java
@@ -60,7 +60,7 @@ class CryptoControllerTest {
     CryptoController subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         txnObserver = mock(StreamObserver.class);
         queryObserver = mock(StreamObserver.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/FileControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/FileControllerTest.java
@@ -50,7 +50,7 @@ class FileControllerTest {
     FileController subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         answers = mock(FileAnswers.class);
         txnObserver = mock(StreamObserver.class);
         queryObserver = mock(StreamObserver.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/FreezeControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/FreezeControllerTest.java
@@ -35,7 +35,7 @@ class FreezeControllerTest {
     FreezeController subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         txnResponseHelper = mock(TxnResponseHelper.class);
 
         subject = new FreezeController(txnResponseHelper);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/NetworkControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/NetworkControllerTest.java
@@ -44,7 +44,7 @@ class NetworkControllerTest {
     NetworkController subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         answers = mock(MetaAnswers.class);
         txnObserver = mock(StreamObserver.class);
         queryObserver = mock(StreamObserver.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/ScheduleControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/ScheduleControllerTest.java
@@ -47,7 +47,7 @@ class ScheduleControllerTest {
     ScheduleController subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         answers = mock(ScheduleAnswers.class);
         txnObserver = mock(StreamObserver.class);
         queryObserver = mock(StreamObserver.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/TokenControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/TokenControllerTest.java
@@ -62,7 +62,7 @@ class TokenControllerTest {
     TokenController subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         answers = mock(TokenAnswers.class);
         txnObserver = mock(StreamObserver.class);
         queryObserver = mock(StreamObserver.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/UtilControllerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/controllers/UtilControllerTest.java
@@ -35,7 +35,7 @@ class UtilControllerTest {
     UtilController subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         txnResponseHelper = mock(TxnResponseHelper.class);
 
         subject = new UtilController(txnResponseHelper);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/AliasResolverTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/grpc/marshalling/AliasResolverTest.java
@@ -56,7 +56,7 @@ class AliasResolverTest {
     private AliasResolver subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new AliasResolver();
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/DefaultActivationCharacteristicsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/DefaultActivationCharacteristicsTest.java
@@ -32,7 +32,7 @@ class DefaultActivationCharacteristicsTest {
     KeyActivationCharacteristics subject = DEFAULT_ACTIVATION_CHARACTERISTICS;
 
     @BeforeEach
-    void setup() throws Exception {
+    void setUp() throws Exception {
         l = TxnHandlingScenario.MISC_FILE_WACL_KT.asJKey().getKeyList();
         t = TxnHandlingScenario.LONG_THRESHOLD_KT.asJKey().getThresholdKey();
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/HederaKeyActivationTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/HederaKeyActivationTest.java
@@ -96,7 +96,7 @@ class HederaKeyActivationTest {
     }
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         sigsFn = (Function<byte[], TransactionSignature>) mock(Function.class);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/InHandleActivationHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/InHandleActivationHelperTest.java
@@ -63,7 +63,7 @@ class InHandleActivationHelperTest {
 
     @BeforeEach
     @SuppressWarnings("unchecked")
-    void setup() {
+    void setUp() {
         scheduled.setForScheduledTxn(true);
         secp256k1Scheduled.setForScheduledTxn(true);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/RevocationServiceCharacteristicsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/keys/RevocationServiceCharacteristicsTest.java
@@ -29,7 +29,7 @@ class RevocationServiceCharacteristicsTest {
     private JThresholdKey t;
 
     @BeforeEach
-    void setup() throws Exception {
+    void setUp() throws Exception {
         l = TxnHandlingScenario.MISC_FILE_WACL_KT.asJKey().getKeyList();
         t = TxnHandlingScenario.LONG_THRESHOLD_KT.asJKey().getThresholdKey();
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerLiveTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerLiveTest.java
@@ -75,7 +75,7 @@ class HederaLedgerLiveTest extends BaseHederaLedgerTestHelper {
     final SideEffectsTracker liveSideEffects = new SideEffectsTracker();
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         commonSetup();
 
         accountsLedger = new TransactionalLedger<>(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerTest.java
@@ -76,7 +76,7 @@ class HederaLedgerTest extends BaseHederaLedgerTestHelper {
     private AutoCreationLogic autoCreationLogic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         commonSetup();
         setupWithMockLedger();
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerTokenXfersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerTokenXfersTest.java
@@ -33,7 +33,7 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class HederaLedgerTokenXfersTest extends BaseHederaLedgerTestHelper {
     @BeforeEach
-    void setup() {
+    void setUp() {
         commonSetup();
         setupWithMockLedger();
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerTokensTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerTokensTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 
 class HederaLedgerTokensTest extends BaseHederaLedgerTestHelper {
     @BeforeEach
-    void setup() {
+    void setUp() {
         commonSetup();
         setupWithMockLedger();
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerXfersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/HederaLedgerXfersTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 class HederaLedgerXfersTest extends BaseHederaLedgerTestHelper {
     @BeforeEach
-    void setup() {
+    void setUp() {
         commonSetup();
         setupWithMockLedger();
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/BackingTokensTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/BackingTokensTest.java
@@ -43,7 +43,7 @@ class BackingTokensTest {
     private BackingTokens subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         map = new MerkleMap<>();
 
         map.put(aKey, aValue);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/accounts/staking/EndOfStakingPeriodCalculatorTest.java
@@ -80,7 +80,7 @@ class EndOfStakingPeriodCalculatorTest {
     private final int sumOfConsensusWeights = 500;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new EndOfStakingPeriodCalculator(
                 () -> AccountStorageAdapter.fromInMemory(MerkleMapLike.from(accounts)),
                 () -> MerkleMapLike.from(stakingInfos),

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingAccountsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingAccountsTest.java
@@ -61,7 +61,7 @@ class BackingAccountsTest {
     private BackingAccounts subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         delegate = new MerkleMap<>();
         delegate.put(aKey, aValue);
         delegate.put(bKey, bValue);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokenRelsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/BackingTokenRelsTest.java
@@ -71,7 +71,7 @@ class BackingTokenRelsTest {
     private BackingTokenRels subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         rels = new MerkleMap<>();
         rels.put(aKey, aValue);
         rels.put(bKey, bValue);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/pure/PureBackingAccountsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/backing/pure/PureBackingAccountsTest.java
@@ -50,7 +50,7 @@ class PureBackingAccountsTest {
     private PureBackingAccounts subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         map = mock(MerkleMap.class);
 
         subject = new PureBackingAccounts(() -> AccountStorageAdapter.fromInMemory(MerkleMapLike.from(map)));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/ids/SeqNoEntityIdSourceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/ids/SeqNoEntityIdSourceTest.java
@@ -43,7 +43,7 @@ class SeqNoEntityIdSourceTest {
     SeqNoEntityIdSource subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         seqNo = mock(SequenceNumber.class);
         subject = new SeqNoEntityIdSource(() -> seqNo);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/ChangeSummaryManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/ledger/properties/ChangeSummaryManagerTest.java
@@ -41,7 +41,7 @@ class ChangeSummaryManagerTest {
     private PropertyChangeObserver<Long, TestAccountProperty> observer;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         changes.clear();
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/AbstractAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/AbstractAnswerTest.java
@@ -56,7 +56,7 @@ class AbstractAnswerTest {
     AbstractAnswer subject;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         query = mock(Query.class);
         view = mock(StateView.class);
         response = mock(Response.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/QueryResponseHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/QueryResponseHelperTest.java
@@ -48,7 +48,7 @@ class QueryResponseHelperTest {
     QueryResponseHelper subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         answerFlow = mock(AnswerFlow.class);
         opCounters = mock(HapiOpCounters.class);
         answer = mock(AnswerService.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/ZeroStakeAnswerFlowTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/answering/ZeroStakeAnswerFlowTest.java
@@ -61,7 +61,7 @@ class ZeroStakeAnswerFlowTest {
     private ZeroStakeAnswerFlow subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ZeroStakeAnswerFlow(queryHeaderValidity, () -> view, throttles);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/consensus/GetMerkleTopicInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/consensus/GetMerkleTopicInfoAnswerTest.java
@@ -86,7 +86,7 @@ class GetMerkleTopicInfoAnswerTest {
     NetworkInfo networkInfo;
 
     @BeforeEach
-    void setup() throws Exception {
+    void setUp() throws Exception {
         adminKey = COMPLEX_KEY_ACCOUNT_KT.asKey();
         submitKey = MISC_ACCOUNT_KT.asKey();
         topics = mock(MerkleMapLike.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/ContractCallLocalAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/ContractCallLocalAnswerTest.java
@@ -131,7 +131,7 @@ class ContractCallLocalAnswerTest {
     private ContractCallLocalAnswer subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ContractCallLocalAnswer(
                 ids,
                 aliasManager,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetBytecodeAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetBytecodeAnswerTest.java
@@ -70,7 +70,7 @@ class GetBytecodeAnswerTest {
     GetBytecodeAnswer subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         contracts = mock(MerkleMap.class);
 
         view = mock(StateView.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetContractInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/contract/GetContractInfoAnswerTest.java
@@ -103,7 +103,7 @@ class GetContractInfoAnswerTest {
     GetContractInfoAnswer subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         info = ContractGetInfoResponse.ContractInfo.newBuilder()
                 .setLedgerId(ledgerId)
                 .setContractID(asContract(target))

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountBalanceAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountBalanceAnswerTest.java
@@ -88,7 +88,7 @@ class GetAccountBalanceAnswerTest {
     private GetAccountBalanceAnswer subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new GetAccountBalanceAnswer(aliasManager, optionValidator, dynamicProperties);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountInfoAnswerTest.java
@@ -148,7 +148,7 @@ class GetAccountInfoAnswerTest {
     private GetAccountInfoAnswer subject;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         tokenRels = TokenRelStorageAdapter.fromInMemory(new MerkleMap<>());
 
         final var firstRel = new MerkleTokenRelStatus(firstBalance, true, true, true);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountRecordsAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/crypto/GetAccountRecordsAnswerTest.java
@@ -78,7 +78,7 @@ class GetAccountRecordsAnswerTest {
     private final GlobalDynamicProperties dynamicProperties = new MockGlobalDynamicProps();
 
     @BeforeEach
-    void setup() throws Exception {
+    void setUp() throws Exception {
         payerAccount = MerkleAccountFactory.newAccount()
                 .accountKeys(COMPLEX_KEY_ACCOUNT_KT)
                 .proxy(asAccount("1.2.3"))

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/file/GetFileContentsAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/file/GetFileContentsAnswerTest.java
@@ -68,7 +68,7 @@ class GetFileContentsAnswerTest {
     GetFileContentsAnswer subject;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         info = FileGetInfoResponse.FileInfo.newBuilder()
                 .setDeleted(false)
                 .setExpirationTime(Timestamp.newBuilder().setSeconds(expiry))

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/file/GetFileInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/file/GetFileInfoAnswerTest.java
@@ -68,7 +68,7 @@ class GetFileInfoAnswerTest {
     GetFileInfoAnswer subject;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         expected = FileGetInfoResponse.FileInfo.newBuilder()
                 .setLedgerId(ledgerId)
                 .setDeleted(false)

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetAccountDetailsAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetAccountDetailsAnswerTest.java
@@ -145,7 +145,7 @@ class GetAccountDetailsAnswerTest {
     private GetAccountDetailsAnswer subject;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         tokenRels = TokenRelStorageAdapter.fromInMemory(new MerkleMap<>());
 
         final var firstRel = new MerkleTokenRelStatus(firstBalance, true, true, true);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetTxnReceiptAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetTxnReceiptAnswerTest.java
@@ -70,7 +70,7 @@ class GetTxnReceiptAnswerTest {
     GetTxnReceiptAnswer subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         view = null;
         recordCache = mock(RecordCache.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetTxnRecordAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetTxnRecordAnswerTest.java
@@ -100,7 +100,7 @@ class GetTxnRecordAnswerTest {
     private NodeLocalProperties nodeProps;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         recordCache = mock(RecordCache.class);
         accounts = mock(MerkleMap.class);
         nodeProps = mock(NodeLocalProperties.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetVersionInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/meta/GetVersionInfoAnswerTest.java
@@ -54,7 +54,7 @@ class GetVersionInfoAnswerTest {
     private GetVersionInfoAnswer subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         view = mock(StateView.class);
         semanticVersions = mock(SemanticVersions.class);
         given(semanticVersions.getDeployed()).willReturn(new ActiveVersions(expectedVersions, expectedVersions));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/schedule/GetScheduleInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/schedule/GetScheduleInfoAnswerTest.java
@@ -75,7 +75,7 @@ class GetScheduleInfoAnswerTest {
     GetScheduleInfoAnswer subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         info = ScheduleInfo.newBuilder()
                 .setLedgerId(ledgerId)
                 .setScheduleID(scheduleID)

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/schedule/ScheduleAnswersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/schedule/ScheduleAnswersTest.java
@@ -26,7 +26,7 @@ class ScheduleAnswersTest {
     GetScheduleInfoAnswer scheduleInfo;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         scheduleInfo = mock(GetScheduleInfoAnswer.class);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetTokenInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetTokenInfoAnswerTest.java
@@ -71,7 +71,7 @@ class GetTokenInfoAnswerTest {
     GetTokenInfoAnswer subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         info = TokenInfo.newBuilder()
                 .setLedgerId(ledgerId)
                 .setTokenId(tokenId)

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfoAnswerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/GetTokenNftInfoAnswerTest.java
@@ -79,7 +79,7 @@ class GetTokenNftInfoAnswerTest {
     GetTokenNftInfoAnswer subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         info = TokenNftInfo.newBuilder()
                 .setLedgerId(ledgerId)
                 .setNftID(nftId)

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/TokenAnswersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/token/TokenAnswersTest.java
@@ -29,7 +29,7 @@ class TokenAnswersTest {
     GetAccountNftInfosAnswer accountNftInfos;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         tokenInfo = mock(GetTokenInfoAnswer.class);
         nftInfo = mock(GetTokenNftInfoAnswer.class);
         tokenNftsInfo = mock(GetTokenNftInfosAnswer.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/validation/QueryFeeCheckTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/queries/validation/QueryFeeCheckTest.java
@@ -81,7 +81,7 @@ class QueryFeeCheckTest {
     private QueryFeeCheck subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         detached = mock(MerkleAccount.class);
         given(detached.getBalance()).willReturn(0L);
         broke = mock(MerkleAccount.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/RecordCacheTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/RecordCacheTest.java
@@ -87,7 +87,7 @@ class RecordCacheTest {
     private RecordCache subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new RecordCache(receiptCache, histories);
 
         subject.setCreator(creator);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TxnIdRecentHistoryTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/records/TxnIdRecentHistoryTest.java
@@ -48,7 +48,7 @@ class TxnIdRecentHistoryTest {
     private TxnIdRecentHistory subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new TxnIdRecentHistory();
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/HederaToPlatformSigOpsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/HederaToPlatformSigOpsTest.java
@@ -79,7 +79,7 @@ class HederaToPlatformSigOpsTest {
     }
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         allSigBytes = mock(PubKeyToSigBytes.class);
         keyOrdering = mock(SigRequirements.class);
         platformTxn = PlatformTxnAccessor.from(newSignedSystemDelete().get());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/PlatformSigOpsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/PlatformSigOpsTest.java
@@ -65,7 +65,7 @@ class PlatformSigOpsTest {
     private TxnScopedPlatformSigFactory sigFactory;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         pubKeys.clear();
         sigBytes = mock(PubKeyToSigBytes.class);
         sigFactory = mock(TxnScopedPlatformSigFactory.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/DelegatingSigMetadataLookupTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/DelegatingSigMetadataLookupTest.java
@@ -59,7 +59,7 @@ class DelegatingSigMetadataLookupTest {
     private Function<TokenID, SafeLookupResult<TokenSigningMetadata>> subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         tokenStore = mock(TokenStore.class);
 
         subject = DelegatingSigMetadataLookup.REF_LOOKUP_FACTORY.apply(tokenStore);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/ScheduleDelegatingSigMetadataLookupTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/metadata/ScheduleDelegatingSigMetadataLookupTest.java
@@ -48,7 +48,7 @@ class ScheduleDelegatingSigMetadataLookupTest {
     Function<ScheduleID, SafeLookupResult<ScheduleSigningMetadata>> subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         schedule = ScheduleVirtualValue.from(
                 scheduleCreateTxnWith(
                                 TxnHandlingScenario.TOKEN_ADMIN_KT.asKey(),

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/verification/PrecheckKeyReqsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/verification/PrecheckKeyReqsTest.java
@@ -50,7 +50,7 @@ class PrecheckKeyReqsTest {
     private final CodeOrderResultFactory factory = CODE_ORDER_RESULT_FACTORY;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         keyOrder = mock(SigRequirements.class);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/verification/PrecheckVerifierTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/sigs/verification/PrecheckVerifierTest.java
@@ -102,7 +102,7 @@ class PrecheckVerifierTest {
     }
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         precheckKeyReqs = mock(PrecheckKeyReqs.class);
         mockAccessor = mock(SignedTxnAccessor.class);
         given(mockAccessor.getTxn()).willReturn(realAccessor.getTxn());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiringCreationsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiringCreationsTest.java
@@ -146,7 +146,7 @@ class ExpiringCreationsTest {
             List.of(new FcTokenAssociation(customFeeToken.num(), customFeeCollector.num()));
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ExpiringCreations(expiries, narratedCharging, dynamicProperties, () -> payerRecords);
         subject.setLedger(ledger);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiringEntityTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/ExpiringEntityTest.java
@@ -35,7 +35,7 @@ class ExpiringEntityTest {
     private ExpiringEntity subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         consumer = mock(Consumer.class);
         otherConsumer = mock(Consumer.class);
         subject = new ExpiringEntity(id, consumer, expiry);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/MonotonicFullQueueExpiriesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/MonotonicFullQueueExpiriesTest.java
@@ -31,7 +31,7 @@ class MonotonicFullQueueExpiriesTest {
     MonotonicFullQueueExpiries<String> subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new MonotonicFullQueueExpiries<>();
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/PriorityQueueExpiriesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/expiry/PriorityQueueExpiriesTest.java
@@ -40,7 +40,7 @@ class PriorityQueueExpiriesTest {
     };
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new PriorityQueueExpiries<>(testCmp);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListenerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/forensics/ServicesIssListenerTest.java
@@ -71,7 +71,7 @@ class ServicesIssListenerTest {
     private ServicesIssListener subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ServicesIssListener(issEventInfo, platform);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/BackedSystemAccountsCreatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/BackedSystemAccountsCreatorTest.java
@@ -78,7 +78,7 @@ class BackedSystemAccountsCreatorTest {
 
     @BeforeEach
     @SuppressWarnings("unchecked")
-    void setup() throws InvalidKeyException, NegativeAccountBalanceException, IllegalArgumentException {
+    void setUp() throws InvalidKeyException, NegativeAccountBalanceException, IllegalArgumentException {
         genesisKey = JKey.mapKey(Key.newBuilder()
                 .setKeyList(KeyList.newBuilder().addKeys(MiscUtils.asKeyUnchecked(pretendKey)))
                 .build());

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/HfsSystemFilesManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/initialization/HfsSystemFilesManagerTest.java
@@ -155,7 +155,7 @@ class HfsSystemFilesManagerTest {
 
     @BeforeEach
     @SuppressWarnings("unchecked")
-    void setup() throws InvalidKeyException {
+    void setUp() throws InvalidKeyException {
         final var keyBytes = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".getBytes();
         masterKey = new JEd25519Key(keyBytes);
         expectedInfo = new HFileMeta(

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/ServicesTxnManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/logic/ServicesTxnManagerTest.java
@@ -108,7 +108,7 @@ class ServicesTxnManagerTest {
     private ServicesTxnManager subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ServicesTxnManager(
                 processLogic,
                 triggeredProcessLogic,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccountStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccountStateTest.java
@@ -127,7 +127,7 @@ class MerkleAccountStateTest {
     private MerkleAccountState subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         cryptoAllowances.put(spenderNum1, cryptoAllowance);
         approveForAllNfts.add(tokenAllowanceKey2);
         fungibleTokenAllowances.put(tokenAllowanceKey1, tokenAllowanceVal);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccountTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleAccountTest.java
@@ -100,7 +100,7 @@ class MerkleAccountTest {
     private MerkleAccount subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         payerRecords = mock(FCQueue.class);
         given(payerRecords.copy()).willReturn(payerRecords);
         given(payerRecords.isImmutable()).willReturn(false);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleNetworkContextTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleNetworkContextTest.java
@@ -119,7 +119,7 @@ class MerkleNetworkContextTest {
     private MerkleNetworkContext subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         congestionStarts =
                 new Instant[] {Instant.ofEpochSecond(1_234_567L, 54321L), Instant.ofEpochSecond(1_234_789L, 12345L)};
         evmCongestionStarts =

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduleTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduleTest.java
@@ -74,7 +74,7 @@ public class MerkleScheduleTest {
     private MerkleSchedule subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         signatories = new ArrayList<>();
         signatories.addAll(List.of(fpk, spk, tpk));
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactionsStateTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactionsStateTest.java
@@ -33,7 +33,7 @@ class MerkleScheduledTransactionsStateTest {
     private MerkleScheduledTransactionsState subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new MerkleScheduledTransactionsState(currentMinSecond);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactionsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleScheduledTransactionsTest.java
@@ -51,7 +51,7 @@ class MerkleScheduledTransactionsTest {
     private MerkleScheduledTransactions subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         byEquality = mock(MerkleMap.class);
         given(byEquality.copy()).willReturn(byEquality);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenRelStatusTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenRelStatusTest.java
@@ -51,7 +51,7 @@ class MerkleTokenRelStatusTest {
     private MerkleTokenRelStatus subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new MerkleTokenRelStatus(balance, frozen, kycGranted, automaticAssociation, numbers);
         subject.setNext(nextTokenNum);
         subject.setPrev(prevTokenNum);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleTokenTest.java
@@ -108,7 +108,7 @@ class MerkleTokenTest {
     private MerkleToken subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new MerkleToken(
                 expiry,
                 totalSupply,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleUniqueTokenTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/MerkleUniqueTokenTest.java
@@ -50,7 +50,7 @@ class MerkleUniqueTokenTest {
     private static long timestampL = 1_234_567L;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         owner = new EntityId(0, 0, 3);
         otherOwner = new EntityId(0, 0, 4);
         spender = new EntityId(0, 0, 5);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/internals/BlobKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/merkle/internals/BlobKeyTest.java
@@ -33,7 +33,7 @@ class BlobKeyTest {
     private BlobKey subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new BlobKey(FILE_DATA, 2);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ContractNonceInfoTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ContractNonceInfoTest.java
@@ -53,7 +53,7 @@ class ContractNonceInfoTest {
     private ContractNonceInfo subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ContractNonceInfo(contractId, nonce);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/CurrencyAdjustmentsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/CurrencyAdjustmentsTest.java
@@ -62,7 +62,7 @@ class CurrencyAdjustmentsTest {
     private CurrencyAdjustments subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new CurrencyAdjustments();
         subject.accountNums = new long[] {a.getAccountNum(), b.getAccountNum(), c.getAccountNum()};
         subject.hbars = new long[] {aAmount, bAmount, cAmount};

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EntityIdTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EntityIdTest.java
@@ -88,7 +88,7 @@ class EntityIdTest {
     private EntityId subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new EntityId(shard, realm, num);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmFnResultTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmFnResultTest.java
@@ -93,7 +93,7 @@ class EvmFnResultTest {
     private EvmFnResult subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new EvmFnResult(
                 contractId,
                 result,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmLogTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/EvmLogTest.java
@@ -45,7 +45,7 @@ class EvmLogTest {
     private EvmLog subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new EvmLog(aLoggerId, bloom, aTopics, data);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExchangeRatesTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExchangeRatesTest.java
@@ -59,7 +59,7 @@ class ExchangeRatesTest {
     private ExchangeRates subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ExchangeRates(
                 expCurrentHbarEquiv,
                 expCurrentCentEquiv,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecordTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/ExpirableTxnRecordTest.java
@@ -102,7 +102,7 @@ class ExpirableTxnRecordTest {
     private ExpirableTxnRecord subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = subjectRecordWithTokenTransfersAndScheduleRefCustomFees();
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceIdTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceIdTest.java
@@ -36,7 +36,7 @@ class FcTokenAllowanceIdTest {
     private FcTokenAllowanceId subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = FcTokenAllowanceId.from(tokenNum, spenderNum);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/FcTokenAllowanceTest.java
@@ -38,7 +38,7 @@ class FcTokenAllowanceTest {
     private FcTokenAllowance subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         serialNums.add(1L);
         serialNums.add(2L);
         subject = FcTokenAllowance.from(approvedForAll, serialNums);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/RichInstantTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/RichInstantTest.java
@@ -40,7 +40,7 @@ class RichInstantTest {
     private RichInstant subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new RichInstant(seconds, nanos);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/SequenceNumberTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/submerkle/SequenceNumberTest.java
@@ -34,7 +34,7 @@ class SequenceNumberTest {
     SequenceNumber defaultSubject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         initSubject = new SequenceNumber(startNo);
         defaultSubject = new SequenceNumber();
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/validation/BasedLedgerValidatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/validation/BasedLedgerValidatorTest.java
@@ -48,7 +48,7 @@ class BasedLedgerValidatorTest {
     BasedLedgerValidator subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         hederaNums = mock(HederaNumbers.class);
         given(hederaNums.realm()).willReturn(realm);
         given(hederaNums.shard()).willReturn(shard);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/ContractValueTest.java
@@ -54,7 +54,7 @@ class ContractValueTest {
     private ContractValue subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ContractValue(bytesValue);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/EntityNumVirtualKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/EntityNumVirtualKeyTest.java
@@ -42,7 +42,7 @@ class EntityNumVirtualKeyTest {
     private EntityNumVirtualKey subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new EntityNumVirtualKey(longKey);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/IterableContractValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/IterableContractValueTest.java
@@ -69,7 +69,7 @@ class IterableContractValueTest {
     private IterableContractValue subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new IterableContractValue(bytesValue, explicitPrevKey, explicitNextKey);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobKeyTest.java
@@ -44,7 +44,7 @@ class VirtualBlobKeyTest {
     private VirtualBlobKey subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new VirtualBlobKey(FILE_DATA, entityNum);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/VirtualBlobValueTest.java
@@ -42,7 +42,7 @@ class VirtualBlobValueTest {
     private byte[] otherData = "someOtherData".getBytes();
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new VirtualBlobValue(data);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualKeyTest.java
@@ -40,7 +40,7 @@ class ScheduleEqualityVirtualKeyTest {
     private ScheduleEqualityVirtualKey subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ScheduleEqualityVirtualKey(longKey);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleEqualityVirtualValueTest.java
@@ -51,7 +51,7 @@ class ScheduleEqualityVirtualValueTest {
             "dog", 4L);
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ScheduleEqualityVirtualValue(ids, new ScheduleEqualityVirtualKey(3L));
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleSecondVirtualValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleSecondVirtualValueTest.java
@@ -52,7 +52,7 @@ class ScheduleSecondVirtualValueTest {
             new RichInstant(300L, 400), LongLists.immutable.of(800L));
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ScheduleSecondVirtualValue(ids, new SecondSinceEpocVirtualKey(3L));
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleVirtualValueTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/schedule/ScheduleVirtualValueTest.java
@@ -81,7 +81,7 @@ public class ScheduleVirtualValueTest {
     private ScheduleVirtualValue subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         signatories = new ArrayList<>();
         signatories.addAll(List.of(fpk, spk, tpk));
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/temporal/SecondSinceEpocVirtualKeyTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/state/virtual/temporal/SecondSinceEpocVirtualKeyTest.java
@@ -40,7 +40,7 @@ class SecondSinceEpocVirtualKeyTest {
     private SecondSinceEpocVirtualKey subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new SecondSinceEpocVirtualKey(longKey);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ExpiryStatsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ExpiryStatsTest.java
@@ -55,7 +55,7 @@ class ExpiryStatsTest {
     private ExpiryStats subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ExpiryStats(halfLife);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/HapiOpCountersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/HapiOpCountersTest.java
@@ -54,7 +54,7 @@ class HapiOpCountersTest {
     private HapiOpCounters subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         HapiOpCounters.setAllFunctions(
                 () -> new HederaFunctionality[] {CryptoTransfer, TokenGetInfo, ConsensusSubmitMessage, NONE});
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/HapiOpSpeedometersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/HapiOpSpeedometersTest.java
@@ -76,7 +76,7 @@ class HapiOpSpeedometersTest {
     private HapiOpSpeedometers subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         HapiOpSpeedometers.allFunctions = () -> new HederaFunctionality[] {CryptoTransfer, TokenGetInfo};
         final Function<HederaFunctionality, String> statNameFn = HederaFunctionality::toString;
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/MiscRunningAvgsTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/MiscRunningAvgsTest.java
@@ -57,7 +57,7 @@ class MiscRunningAvgsTest {
     private MiscRunningAvgs subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new MiscRunningAvgs(halfLife);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/MiscSpeedometersTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/MiscSpeedometersTest.java
@@ -51,7 +51,7 @@ class MiscSpeedometersTest {
     private MiscSpeedometers subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         platform = mock(Platform.class);
         final var platformContext = mock(PlatformContext.class);
         given(platform.getContext()).willReturn(platformContext);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ServicesStatsManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/stats/ServicesStatsManagerTest.java
@@ -110,7 +110,7 @@ class ServicesStatsManagerTest {
     ServicesStatsManager subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         ServicesStatsManager.loopFactory = threads;
         ServicesStatsManager.pause = pause;
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/TopicStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/TopicStoreTest.java
@@ -46,7 +46,7 @@ class TopicStoreTest {
     private TopicStore subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new TopicStore(() -> MerkleMapLike.from(topics), transactionRecordService);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenExpiryWrapperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/contracts/precompile/TokenExpiryWrapperTest.java
@@ -31,7 +31,7 @@ class TokenExpiryWrapperTest {
     private TokenExpiryWrapper wrapper;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         wrapper = createTokenExpiryWrapper();
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/OwnershipTrackerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/models/OwnershipTrackerTest.java
@@ -30,7 +30,7 @@ class OwnershipTrackerTest {
     private final Id token = new Id(0, 0, 1);
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         // setup the getter/setter test
         subject = new OwnershipTracker();
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/schedule/HederaScheduleStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/schedule/HederaScheduleStoreTest.java
@@ -130,7 +130,7 @@ class HederaScheduleStoreTest {
     private HederaScheduleStore subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         schedule = mock(ScheduleVirtualValue.class);
         anotherSchedule = mock(ScheduleVirtualValue.class);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/tokens/HederaTokenStoreTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/store/tokens/HederaTokenStoreTest.java
@@ -199,7 +199,7 @@ class HederaTokenStoreTest {
     private HederaTokenStore subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         token = mock(MerkleToken.class);
         given(token.expiry()).willReturn(expiry);
         given(token.symbol()).willReturn(symbol);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/TransactionThrottlingTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/throttling/TransactionThrottlingTest.java
@@ -35,7 +35,7 @@ class TransactionThrottlingTest {
     TransactionThrottling subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         functionalThrottling = mock(FunctionalityThrottling.class);
 
         subject = new TransactionThrottling(functionalThrottling);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/MerkleTopicDeleteTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/MerkleTopicDeleteTransitionLogicTest.java
@@ -67,7 +67,7 @@ class MerkleTopicDeleteTransitionLogicTest {
     MerkleTopic deletableTopic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         consensusTime = Instant.ofEpochSecond(1546304461);
 
         transactionContext = mock(TransactionContext.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/MerkleTopicUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/MerkleTopicUpdateTransitionLogicTest.java
@@ -107,7 +107,7 @@ class MerkleTopicUpdateTransitionLogicTest {
     private final AccountID payer = AccountID.newBuilder().setAccountNum(1_234L).build();
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         consensusTime = Instant.ofEpochSecond(NOW_SECONDS);
         updatedExpirationTime =
                 Instant.ofEpochSecond(EXISTING_EXPIRATION_TIME.getSeconds()).plusSeconds(1000);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/SubmitMessageTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/SubmitMessageTransitionLogicTest.java
@@ -68,7 +68,7 @@ class SubmitMessageTransitionLogicTest {
     private final AccountID payer = AccountID.newBuilder().setAccountNum(1_234L).build();
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         consensusTime = Instant.ofEpochSecond(EPOCH_SECOND);
 
         transactionContext = mock(TransactionContext.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/TopicCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/consensus/TopicCreateTransitionLogicTest.java
@@ -113,7 +113,7 @@ class TopicCreateTransitionLogicTest {
     private TopicCreateTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         accounts.clear();
         topics.clear();
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCallTransitionLogicTest.java
@@ -162,7 +162,7 @@ class ContractCallTransitionLogicTest {
     ContractCallTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ContractCallTransitionLogic(
                 txnCtx,
                 accountStore,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractCreateTransitionLogicTest.java
@@ -202,7 +202,7 @@ class ContractCreateTransitionLogicTest {
     private MockedStatic<SidecarUtils> sidecarUtilsMockedStatic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         sidecarUtilsMockedStatic = mockStatic(SidecarUtils.class);
         subject = new ContractCreateTransitionLogic(
                 hfs,

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractDeleteTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractDeleteTransitionLogicTest.java
@@ -52,7 +52,7 @@ class ContractDeleteTransitionLogicTest {
     ContractDeleteTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         consensusTime = Instant.now();
 
         deletionLogic = mock(DeletionLogic.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractSysDelTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractSysDelTransitionLogicTest.java
@@ -75,7 +75,7 @@ class ContractSysDelTransitionLogicTest {
     ContractSysDelTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         consensusTime = Instant.now();
 
         delegate = mock(ContractSysDelTransitionLogic.LegacySystemDeleter.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractSysUndelTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractSysUndelTransitionLogicTest.java
@@ -76,7 +76,7 @@ class ContractSysUndelTransitionLogicTest {
     ContractSysUndelTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         consensusTime = Instant.now();
 
         delegate = mock(ContractSysUndelTransitionLogic.LegacySystemUndeleter.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/contract/ContractUpdateTransitionLogicTest.java
@@ -107,7 +107,7 @@ class ContractUpdateTransitionLogicTest {
     private NodeInfo nodeInfo;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         consensusTime = Instant.now();
 
         ledger = mock(HederaLedger.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/ApproveAllowanceLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/ApproveAllowanceLogicTest.java
@@ -123,7 +123,7 @@ class ApproveAllowanceLogicTest {
     private final UniqueToken nft2 = new UniqueToken(tokenId2, serial2);
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new ApproveAllowanceLogic(accountStore, tokenStore, dynamicProperties);
         nft1.setOwner(Id.fromGrpcAccount(ownerId));
         nft2.setOwner(Id.fromGrpcAccount(ownerId));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoApproveAllowanceTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoApproveAllowanceTransitionLogicTest.java
@@ -83,7 +83,7 @@ class CryptoApproveAllowanceTransitionLogicTest {
     CryptoApproveAllowanceTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new CryptoApproveAllowanceTransitionLogic(
                 txnCtx, accountStore, allowanceChecks, approveAllowanceLogic, view);
         nft1.setOwner(fromGrpcAccount(ownerId));

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoCreateTransitionLogicTest.java
@@ -148,7 +148,7 @@ class CryptoCreateTransitionLogicTest {
     private CryptoCreateChecks cryptoCreateChecks;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         txnCtx = mock(TransactionContext.class);
         usageLimits = mock(UsageLimits.class);
         aliasManager = mock(AliasManager.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoDeleteAllowanceTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoDeleteAllowanceTransitionLogicTest.java
@@ -78,7 +78,7 @@ class CryptoDeleteAllowanceTransitionLogicTest {
     CryptoDeleteAllowanceTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new CryptoDeleteAllowanceTransitionLogic(
                 txnCtx, accountStore, deleteAllowanceChecks, view, deleteAllowanceLogic);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoDeleteTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoDeleteTransitionLogicTest.java
@@ -81,7 +81,7 @@ class CryptoDeleteTransitionLogicTest {
     private CryptoDeleteTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         txnCtx = mock(TransactionContext.class);
         ledger = mock(HederaLedger.class);
         accessor = mock(SignedTxnAccessor.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoTransferTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoTransferTransitionLogicTest.java
@@ -123,7 +123,7 @@ class CryptoTransferTransitionLogicTest {
     private CryptoTransferTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new CryptoTransferTransitionLogic(
                 ledger, txnCtx, dynamicProperties, impliedTransfersMarshal, transferSemanticChecks, spanMapAccessor);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/CryptoUpdateTransitionLogicTest.java
@@ -120,7 +120,7 @@ class CryptoUpdateTransitionLogicTest {
     private NodeInfo nodeInfo;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         useLegacyFields = false;
 
         txnCtx = mock(TransactionContext.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/DeleteAllowanceLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/crypto/DeleteAllowanceLogicTest.java
@@ -95,7 +95,7 @@ class DeleteAllowanceLogicTest {
     private static final UniqueToken uniqueToken2 = new UniqueToken(Id.fromGrpcToken(token2), 10L);
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new DeleteAllowanceLogic(accountStore, tokenStore);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileAppendTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileAppendTransitionLogicTest.java
@@ -99,7 +99,7 @@ class FileAppendTransitionLogicTest {
     HederaFileNumbers numbers = new MockFileNumbers();
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         wacl = TxnHandlingScenario.SIMPLE_NEW_WACL_KT.asJKey();
         attr = new HFileMeta(false, wacl, 2_000_000L);
         deletedAttr = new HFileMeta(true, wacl, 2_000_000L);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileCreateTransitionLogicTest.java
@@ -103,7 +103,7 @@ class FileCreateTransitionLogicTest {
     FileCreateTransitionLogic subject;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         hederaWacl = waclSkeleton.asJKey();
         attr = new HFileMeta(false, hederaWacl, expiry);
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileDeleteTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileDeleteTransitionLogicTest.java
@@ -75,7 +75,7 @@ class FileDeleteTransitionLogicTest {
     private FileDeleteTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         accessor = mock(SignedTxnAccessor.class);
         txnCtx = mock(TransactionContext.class);
         sigImpactHistorian = mock(SigImpactHistorian.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileSysDelTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileSysDelTransitionLogicTest.java
@@ -102,7 +102,7 @@ class FileSysDelTransitionLogicTest {
     FileSysDelTransitionLogic subject;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         wacl = TxnHandlingScenario.SIMPLE_NEW_WACL_KT.asJKey();
         attr = new HFileMeta(false, wacl, oldExpiry);
         deletedAttr = new HFileMeta(true, wacl, oldExpiry);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileSysUndelTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileSysUndelTransitionLogicTest.java
@@ -99,7 +99,7 @@ class FileSysUndelTransitionLogicTest {
     FileSysUndelTransitionLogic subject;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         wacl = TxnHandlingScenario.SIMPLE_NEW_WACL_KT.asJKey();
         attr = new HFileMeta(false, wacl, currExpiry);
         deletedAttr = new HFileMeta(true, wacl, currExpiry);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/file/FileUpdateTransitionLogicTest.java
@@ -116,7 +116,7 @@ class FileUpdateTransitionLogicTest {
     FileUpdateTransitionLogic subject;
 
     @BeforeEach
-    void setup() throws Throwable {
+    void setUp() throws Throwable {
         oldWacl = TxnHandlingScenario.SIMPLE_NEW_WACL_KT.asJKey();
         oldAttr = new HFileMeta(false, oldWacl, oldExpiry, oldMemo);
         deletedAttr = new HFileMeta(true, oldWacl, oldExpiry);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/network/FreezeTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/network/FreezeTransitionLogicTest.java
@@ -101,7 +101,7 @@ class FreezeTransitionLogicTest {
     private FreezeTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new FreezeTransitionLogic(upgradeActions, txnCtx, () -> specialFiles, () -> networkCtx);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleCreateTransitionLogicTest.java
@@ -123,7 +123,7 @@ class ScheduleCreateTransitionLogicTest {
     private ScheduleCreateTransitionLogic subject;
 
     @BeforeEach
-    void setup() throws InvalidProtocolBufferException {
+    void setUp() throws InvalidProtocolBufferException {
         validator = mock(OptionValidator.class);
         store = mock(ScheduleStore.class);
         accessor = mock(SignedTxnAccessor.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleDeleteTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleDeleteTransitionLogicTest.java
@@ -67,7 +67,7 @@ class ScheduleDeleteTransitionLogicTest {
     private ScheduleDeleteTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         store = mock(ScheduleStore.class);
         accessor = mock(SignedTxnAccessor.class);
         txnCtx = mock(TransactionContext.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleSignTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/schedule/ScheduleSignTransitionLogicTest.java
@@ -88,7 +88,7 @@ class ScheduleSignTransitionLogicTest {
     private ScheduleProcessing scheduleProcessing;
 
     @BeforeEach
-    void setup() throws InvalidProtocolBufferException {
+    void setUp() throws InvalidProtocolBufferException {
         store = mock(ScheduleStore.class);
         accessor = mock(SignedTxnAccessor.class);
         executor = mock(ScheduleExecutor.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/PlatformSubmissionManagerTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/PlatformSubmissionManagerTest.java
@@ -80,7 +80,7 @@ class PlatformSubmissionManagerTest {
     PlatformSubmissionManager subject;
 
     @BeforeEach
-    void setup() throws InvalidProtocolBufferException {
+    void setUp() throws InvalidProtocolBufferException {
         platform = mock(Platform.class);
         recordCache = mock(RecordCache.class);
         speedometers = mock(MiscSpeedometers.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/SyntaxPrecheckTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/SyntaxPrecheckTest.java
@@ -75,7 +75,7 @@ class SyntaxPrecheckTest {
     private SyntaxPrecheck subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new SyntaxPrecheck(recordCache, validator, dynamicProperties);
 
         txn = TransactionBody.newBuilder()

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/TxnResponseHelperTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/submission/TxnResponseHelperTest.java
@@ -58,7 +58,7 @@ class TxnResponseHelperTest {
     private TxnResponseHelper subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         submissionFlow = mock(SubmissionFlow.class);
         opCounters = mock(HapiOpCounters.class);
         observer = mock(StreamObserver.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/AssociateLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/AssociateLogicTest.java
@@ -74,7 +74,7 @@ class AssociateLogicTest {
     private AssociateLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new AssociateLogic(usageLimits, tokenStore, accountStore, dynamicProperties);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/BurnLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/BurnLogicTest.java
@@ -74,7 +74,7 @@ class BurnLogicTest {
     private BurnLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new BurnLogic(validator, store, accountStore, dynamicProperties);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/DissociateLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/DissociateLogicTest.java
@@ -80,7 +80,7 @@ class DissociateLogicTest {
     private DissociateLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new DissociateLogic(validator, tokenStore, accountStore, relsFactory);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/MintLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/MintLogicTest.java
@@ -92,7 +92,7 @@ class MintLogicTest {
     private MintLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new MintLogic(usageLimits, validator, store, accountStore, dynamicProperties);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/PauseLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/PauseLogicTest.java
@@ -41,7 +41,7 @@ class PauseLogicTest {
     private PauseLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new PauseLogic(store);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenAssociateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenAssociateTransitionLogicTest.java
@@ -74,7 +74,7 @@ class TokenAssociateTransitionLogicTest {
     private GlobalDynamicProperties dynamicProperties;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         associateLogic = new AssociateLogic(usageLimits, tokenStore, accountStore, dynamicProperties);
         subject = new TokenAssociateTransitionLogic(txnCtx, associateLogic);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenBurnTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenBurnTransitionLogicTest.java
@@ -86,7 +86,7 @@ class TokenBurnTransitionLogicTest {
     private TokenBurnTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         burnLogic = new BurnLogic(validator, tokenStore, accountStore, dynamicProperties);
         subject = new TokenBurnTransitionLogic(txnCtx, burnLogic);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenCreateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenCreateTransitionLogicTest.java
@@ -129,7 +129,7 @@ class TokenCreateTransitionLogicTest {
     private TokenCreateTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         createLogic = new CreateLogic(
                 usageLimits, accountStore, tokenStore, dynamicProperties, sigImpactHistorian, ids, validator);
         createChecks = new CreateChecks(dynamicProperties, validator);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenDeleteTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenDeleteTransitionLogicTest.java
@@ -60,7 +60,7 @@ class TokenDeleteTransitionLogicTest {
     private TokenDeleteTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         txnCtx = mock(TransactionContext.class);
         accessor = mock(SignedTxnAccessor.class);
         typedTokenStore = mock(TypedTokenStore.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenFeeScheduleUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenFeeScheduleUpdateTransitionLogicTest.java
@@ -87,7 +87,7 @@ class TokenFeeScheduleUpdateTransitionLogicTest {
     private TokenFeeScheduleUpdateTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new TokenFeeScheduleUpdateTransitionLogic(
                 tokenStore, txnCtx, accountStore, sigImpactHistorian, dynamicProperties);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenFreezeTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenFreezeTransitionLogicTest.java
@@ -69,7 +69,7 @@ class TokenFreezeTransitionLogicTest {
     private TokenFreezeTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         accountStore = mock(AccountStore.class);
         tokenStore = mock(TypedTokenStore.class);
         accessor = mock(SignedTxnAccessor.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenGrantKycTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenGrantKycTransitionLogicTest.java
@@ -69,7 +69,7 @@ class TokenGrantKycTransitionLogicTest {
     private TokenGrantKycTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         accountStore = mock(AccountStore.class);
         tokenStore = mock(TypedTokenStore.class);
         accessor = mock(SignedTxnAccessor.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenMintTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenMintTransitionLogicTest.java
@@ -90,7 +90,7 @@ class TokenMintTransitionLogicTest {
     private TokenMintTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         mintLogic = new MintLogic(usageLimits, validator, tokenStore, accountStore, dynamicProperties);
         subject = new TokenMintTransitionLogic(txnCtx, mintLogic);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenPauseTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenPauseTransitionLogicTest.java
@@ -57,7 +57,7 @@ class TokenPauseTransitionLogicTest {
     private TokenPauseTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         tokenStore = mock(TypedTokenStore.class);
         accessor = mock(SignedTxnAccessor.class);
         token = mock(Token.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenRevokeKycTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenRevokeKycTransitionLogicTest.java
@@ -69,7 +69,7 @@ class TokenRevokeKycTransitionLogicTest {
     private TokenRevokeKycTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         accountStore = mock(AccountStore.class);
         tokenStore = mock(TypedTokenStore.class);
         accessor = mock(SignedTxnAccessor.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenUnfreezeTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenUnfreezeTransitionLogicTest.java
@@ -68,7 +68,7 @@ class TokenUnfreezeTransitionLogicTest {
     private TokenUnfreezeTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         accessor = mock(SignedTxnAccessor.class);
         tokenRelationship = mock(TokenRelationship.class);
         token = mock(Token.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenUnpauseTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenUnpauseTransitionLogicTest.java
@@ -57,7 +57,7 @@ class TokenUnpauseTransitionLogicTest {
     private TokenUnpauseTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         tokenStore = mock(TypedTokenStore.class);
         accessor = mock(SignedTxnAccessor.class);
         token = mock(Token.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenUpdateTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenUpdateTransitionLogicTest.java
@@ -80,7 +80,7 @@ class TokenUpdateTransitionLogicTest {
     private TokenUpdateTransitionLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         validator = mock(OptionValidator.class);
         store = mock(TokenStore.class);
         ledger = mock(HederaLedger.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenWipeTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/TokenWipeTransitionLogicTest.java
@@ -81,7 +81,7 @@ class TokenWipeTransitionLogicTest {
     private Account account;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         swirldsTxnAccessor = mock(SwirldsTxnAccessor.class);
         merkleToken = mock(MerkleToken.class);
         token = mock(Token.class);

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/UnpauseLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/UnpauseLogicTest.java
@@ -41,7 +41,7 @@ class UnpauseLogicTest {
     private UnpauseLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new UnpauseLogic(store);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/WipeLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/token/WipeLogicTest.java
@@ -73,7 +73,7 @@ class WipeLogicTest {
     private WipeLogic subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new WipeLogic(typedTokenStore, accountStore, dynamicProperties);
     }
 

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/util/UtilPrngTransitionLogicTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/util/UtilPrngTransitionLogicTest.java
@@ -68,7 +68,7 @@ class UtilPrngTransitionLogicTest {
     private PrngLogic logic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         logic = new PrngLogic(properties, () -> runningHashLeaf, tracker);
         subject = new UtilPrngTransitionLogic(txnCtx, logic);
     }

--- a/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/validation/ContextOptionValidatorTest.java
+++ b/hedera-node/hedera-mono-service/src/test/java/com/hedera/node/app/service/mono/txns/validation/ContextOptionValidatorTest.java
@@ -150,7 +150,7 @@ class ContextOptionValidatorTest {
     private final FileID target = asFile("0.0.123");
 
     @BeforeEach
-    void setup() throws Exception {
+    void setUp() throws Exception {
         txnCtx = mock(TransactionContext.class);
         given(txnCtx.consensusTime()).willReturn(now);
         accounts = mock(AccountStorageAdapter.class);

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/UnzipUtilityTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/UnzipUtilityTest.java
@@ -60,7 +60,7 @@ class UnzipUtilityTest {
     private final String FILENAME_2 = "subdirectory/subdirectoryFileToZip.txt";
 
     @BeforeEach
-    void setup() throws IOException {
+    void setUp() throws IOException {
         zipSourceDir = Files.createTempDirectory("zipSourceDir");
 
         // set up test zip with one file in it

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/codec/ScheduleServiceStateTranslatorTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/codec/ScheduleServiceStateTranslatorTest.java
@@ -55,7 +55,7 @@ class ScheduleServiceStateTranslatorTest extends ScheduleTestBase {
     private ScheduleVirtualValue subject;
 
     @BeforeEach
-    void setup() throws PreCheckException, InvalidKeyException {
+    void setUp() throws PreCheckException, InvalidKeyException {
         setUpBase();
         protoKey = new EntityNumVirtualKey(scheduleInState.scheduleId().scheduleNum());
         protoBodyBytes = getBodyBytes(scheduleInState);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/setapproval/SetApprovalForAllCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/setapproval/SetApprovalForAllCallTest.java
@@ -63,7 +63,7 @@ public class SetApprovalForAllCallTest extends HtsCallTestBase {
     private SetApprovalForAllCall subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         final Tuple tuple =
                 new Tuple(FUNGIBLE_TOKEN_HEADLONG_ADDRESS, UNAUTHORIZED_SPENDER_HEADLONG_ADDRESS, Boolean.TRUE);
         final byte[] inputBytes = Bytes.wrapByteBuffer(

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/wipe/WipeTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/wipe/WipeTranslatorTest.java
@@ -39,7 +39,7 @@ public class WipeTranslatorTest {
     private WipeTranslator subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new WipeTranslator(decoder);
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/RootProxyWorldUpdaterTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/RootProxyWorldUpdaterTest.java
@@ -94,7 +94,7 @@ class RootProxyWorldUpdaterTest {
     private RootProxyWorldUpdater subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         enhancement =
                 new HederaWorldUpdater.Enhancement(hederaOperations, hederaNativeOperations, systemContractOperations);
         givenSubjectWith(HederaTestConfigBuilder.create().getOrCreateConfig(), enhancement);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/BlocklistParserTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/BlocklistParserTest.java
@@ -32,7 +32,7 @@ class BlocklistParserTest {
     private BlocklistParser subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new BlocklistParser();
     }
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerTest.java
@@ -66,7 +66,7 @@ class TokenFeeScheduleUpdateHandlerTest extends CryptoTokenHandlerTestBase {
     private PreHandleContext preHandleContext;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         super.setUp();
         refreshWritableStores();
         validator = new CustomFeesValidator();

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerTest.java
@@ -65,8 +65,9 @@ class TokenFeeScheduleUpdateHandlerTest extends CryptoTokenHandlerTestBase {
     @Mock
     private PreHandleContext preHandleContext;
 
+    @Override
     @BeforeEach
-    void setUp() {
+    public void setUp() {
         super.setUp();
         refreshWritableStores();
         validator = new CustomFeesValidator();

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFreezeAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFreezeAccountHandlerTest.java
@@ -154,7 +154,7 @@ class TokenFreezeAccountHandlerTest {
         private ExpiryValidator expiryValidator;
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             given(context.readableStore(ReadableTokenStore.class)).willReturn(readableTokenStore);
             given(context.readableStore(ReadableAccountStore.class)).willReturn(readableAccountStore);
             given(context.writableStore(WritableTokenRelationStore.class)).willReturn(tokenRelStore);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGrantKycToAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenGrantKycToAccountHandlerTest.java
@@ -194,7 +194,7 @@ class TokenGrantKycToAccountHandlerTest extends TokenHandlerTestBase {
         private HandleContext handleContext;
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             given(handleContext.writableStore(WritableTokenRelationStore.class)).willReturn(tokenRelStore);
             given(handleContext.readableStore(ReadableTokenStore.class)).willReturn(readableTokenStore);
             given(handleContext.readableStore(ReadableAccountStore.class)).willReturn(readableAccountStore);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerParityTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerParityTest.java
@@ -44,7 +44,7 @@ class TokenMintHandlerParityTest extends ParityTestBase {
     private TokenMintHandler subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         validator = new TokenSupplyChangeOpsValidator();
         subject = new TokenMintHandler(validator);
     }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerParityTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerParityTest.java
@@ -43,8 +43,10 @@ class TokenMintHandlerParityTest extends ParityTestBase {
     private TokenSupplyChangeOpsValidator validator;
     private TokenMintHandler subject;
 
+    @Override
     @BeforeEach
-    void setUp() {
+    public void setUp() {
+        super.setUp();
         validator = new TokenSupplyChangeOpsValidator();
         subject = new TokenMintHandler(validator);
     }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUnfreezeAccountHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUnfreezeAccountHandlerTest.java
@@ -147,7 +147,7 @@ class TokenUnfreezeAccountHandlerTest {
         private ExpiryValidator expiryValidator;
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             given(context.readableStore(ReadableTokenStore.class)).willReturn(tokenStore);
             given(context.readableStore(ReadableAccountStore.class)).willReturn(accountStore);
             given(context.writableStore(WritableTokenRelationStore.class)).willReturn(tokenRelStore);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/EndOfStakingPeriodUpdaterTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/EndOfStakingPeriodUpdaterTest.java
@@ -66,7 +66,7 @@ class EndOfStakingPeriodUpdaterTest {
     private NodeStakeUpdateRecordBuilder nodeStakeUpdateRecordBuilder;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         accountStore = TestStoreFactory.newReadableStoreWithAccounts(Account.newBuilder()
                 .accountId(asAccount(800))
                 .tinybarBalance(100_000_000_000L)

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/util/TokenRelListCalculatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/util/TokenRelListCalculatorTest.java
@@ -44,7 +44,7 @@ class TokenRelListCalculatorTest {
     private TokenRelListCalculator subject;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         subject = new TokenRelListCalculator(localTokenRelsStore());
     }
 

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/MetricsEventBusTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/MetricsEventBusTest.java
@@ -43,7 +43,7 @@ class MetricsEventBusTest {
     private Consumer<Object> subscriber;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         doAnswer(invocation -> {
                     invocation.getArgument(0, Runnable.class).run();
                     return null;

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/PrometheusEndpointTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/PrometheusEndpointTest.java
@@ -99,7 +99,7 @@ class PrometheusEndpointTest {
             new TestConfigBuilder().getOrCreateConfig().getConfigData(MetricsConfig.class);
 
     @BeforeEach
-    void setup() throws IOException {
+    void setUp() throws IOException {
         this.httpServer = HttpServer.create(ADDRESS, 1);
     }
 

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/PlatformStatusStateMachineTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/PlatformStatusStateMachineTests.java
@@ -47,7 +47,7 @@ class PlatformStatusStateMachineTests {
     private PlatformStatusStateMachine stateMachine;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         time = new FakeTime();
         final Configuration configuration = new TestConfigBuilder()
                 .withValue("platformStatus.observingStatusDelay", "5s")

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/ActiveStatusLogicTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/ActiveStatusLogicTests.java
@@ -48,7 +48,7 @@ class ActiveStatusLogicTests {
     private ActiveStatusLogic logic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         time = new FakeTime();
         final Configuration configuration = new TestConfigBuilder()
                 .withValue("platformStatus.activeStatusDelay", "5s")

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/BehindStatusLogicTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/BehindStatusLogicTests.java
@@ -47,7 +47,7 @@ class BehindStatusLogicTests {
     private BehindStatusLogic logic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         time = new FakeTime();
         final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
         logic = new BehindStatusLogic(configuration.getConfigData(PlatformStatusConfig.class));

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/CatastrophicFailureStatusLogicTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/CatastrophicFailureStatusLogicTests.java
@@ -41,7 +41,7 @@ class CatastrophicFailureStatusLogicTests {
     private CatastrophicFailureStatusLogic logic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         time = new FakeTime();
         logic = new CatastrophicFailureStatusLogic();
     }

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/CheckingStatusLogicTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/CheckingStatusLogicTests.java
@@ -47,7 +47,7 @@ class CheckingStatusLogicTests {
     private CheckingStatusLogic logic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         time = new FakeTime();
         final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
         logic = new CheckingStatusLogic(configuration.getConfigData(PlatformStatusConfig.class));

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/FreezeCompleteStateStatusLogicTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/FreezeCompleteStateStatusLogicTests.java
@@ -41,7 +41,7 @@ class FreezeCompleteStateStatusLogicTests {
     private FreezeCompleteStatusLogic logic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         time = new FakeTime();
         logic = new FreezeCompleteStatusLogic();
     }

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/FreezingStatusLogicTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/FreezingStatusLogicTests.java
@@ -45,7 +45,7 @@ class FreezingStatusLogicTests {
     private FreezingStatusLogic logic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         time = new FakeTime();
         logic = new FreezingStatusLogic(testFreezeRound);
     }

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/ObservingStatusLogicTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/ObservingStatusLogicTests.java
@@ -48,7 +48,7 @@ class ObservingStatusLogicTests {
     private ObservingStatusLogic logic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         time = new FakeTime();
         final Configuration configuration = new TestConfigBuilder()
                 .withValue("platformStatus.observingStatusDelay", "5s")

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/ReconnectCompleteStatusLogicTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/ReconnectCompleteStatusLogicTests.java
@@ -48,7 +48,7 @@ class ReconnectCompleteStatusLogicTests {
     private ReconnectCompleteStatusLogic logic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         time = new FakeTime();
         final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
         logic = new ReconnectCompleteStatusLogic(

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/ReplayingEventsStatusLogicTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/ReplayingEventsStatusLogicTests.java
@@ -47,7 +47,7 @@ class ReplayingEventsStatusLogicTests {
     private ReplayingEventsStatusLogic logic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         time = new FakeTime();
         final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
         logic = new ReplayingEventsStatusLogic(configuration.getConfigData(PlatformStatusConfig.class));

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/StartingUpStatusLogicTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/status/logic/StartingUpStatusLogicTests.java
@@ -47,7 +47,7 @@ class StartingUpStatusLogicTests {
     private StartingUpStatusLogic logic;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         time = new FakeTime();
         final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
         logic = new StartingUpStatusLogic(configuration.getConfigData(PlatformStatusConfig.class));

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/transaction/TransactionTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/system/transaction/TransactionTest.java
@@ -39,7 +39,7 @@ public class TransactionTest {
     private static final int MAX_ADDRESSBOOK_SIZE = 2048;
 
     @BeforeAll
-    public static void setup() throws ConstructableRegistryException {
+    public static void setUp() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.common.system");
     }

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/ReplaceSyncPhaseParallelExecutorTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/ReplaceSyncPhaseParallelExecutorTests.java
@@ -44,7 +44,7 @@ class ReplaceSyncPhaseParallelExecutorTests {
     }
 
     @BeforeEach
-    public void setup() {
+    public void setUp() {
         for (final PhaseTask phaseTask : PhaseTask.values()) {
             phaseTask.reset();
         }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/CloseFlushTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/CloseFlushTest.java
@@ -61,7 +61,7 @@ public class CloseFlushTest {
     private static Path tmpFileDir;
 
     @BeforeAll
-    public static void setup() throws IOException {
+    public static void setUp() throws IOException {
         tmpFileDir = TemporaryFileBuilder.buildTemporaryFile();
         Configurator.setRootLevel(Level.WARN);
     }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
@@ -41,7 +41,7 @@ class MerkleDbBuilderTest {
     private static Path testDirectory;
 
     @BeforeAll
-    static void setup() throws IOException {
+    static void setUp() throws IOException {
         testDirectory = TemporaryFileBuilder.buildTemporaryFile("MerkleDbBuilderTest");
     }
 

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceMetricsTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceMetricsTest.java
@@ -58,7 +58,7 @@ class MerkleDbDataSourceMetricsTest {
     private Metrics metrics;
 
     @BeforeAll
-    static void setup() throws Exception {
+    static void setUp() throws Exception {
         testDirectory = TemporaryFileBuilder.buildTemporaryFile("MerkleDbDataSourceMetricsTest");
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds.merkledb");
     }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceTest.java
@@ -68,7 +68,7 @@ class MerkleDbDataSourceTest {
     private static Path testDirectory;
 
     @BeforeAll
-    static void setup() throws Exception {
+    static void setUp() throws Exception {
         testDirectory = TemporaryFileBuilder.buildTemporaryFile("MerkleDbDataSourceTest");
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds.merkledb");
     }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbSnapshotTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbSnapshotTest.java
@@ -69,7 +69,7 @@ class MerkleDbSnapshotTest {
     private static final Random RANDOM = new Random(123);
 
     @BeforeAll
-    static void setup() throws Exception {
+    static void setUp() throws Exception {
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds.common");
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds.merkledb");
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds.virtualmap");

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 public class MerkleDbTest {
 
     @BeforeAll
-    public static void setup() throws Exception {
+    public static void setUp() throws Exception {
         MerkleDb.resetDefaultInstancePath();
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds.merkledb");
     }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionHammerTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionHammerTest.java
@@ -51,7 +51,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class DataFileCollectionCompactionHammerTest {
 
     @BeforeAll
-    public static void setup() {
+    public static void setUp() {
         Configurator.setRootLevel(Level.WARN);
     }
 

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderCloseTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderCloseTest.java
@@ -40,7 +40,7 @@ class DataFileReaderCloseTest {
     private static final DataItemSerializer<long[]> serializer = new TwoLongSerializer();
 
     @BeforeAll
-    static void setup() throws IOException {
+    static void setUp() throws IOException {
         final Path dir = TemporaryFileBuilder.buildTemporaryFile("readerIsOpenTest");
         collection = new DataFileCollection<>(dir, "store", serializer, null);
     }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreCompactionHammerTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreCompactionHammerTest.java
@@ -59,7 +59,7 @@ class MemoryIndexDiskKeyValueStoreCompactionHammerTest {
     Path testDirectory;
 
     @BeforeAll
-    public static void setup() {
+    public static void setUp() {
         Configurator.setRootLevel(Level.WARN);
     }
 

--- a/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/payloads/test/ReconnectPeerInfoPayloadTest.java
+++ b/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/payloads/test/ReconnectPeerInfoPayloadTest.java
@@ -38,7 +38,7 @@ class ReconnectPeerInfoPayloadTest {
     private ReconnectPeerInfoPayload payload;
 
     @BeforeEach
-    public void setup() {
+    public void setUp() {
         payload = new ReconnectPeerInfoPayload();
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SwirldTransactionSubmitterTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SwirldTransactionSubmitterTest.java
@@ -61,7 +61,7 @@ class SwirldTransactionSubmitterTest {
     }
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         random = RandomUtils.getRandom();
         platformStatus = PlatformStatus.ACTIVE;
         final Configuration configuration = new TestConfigBuilder()

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/EventDeduplicatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/EventDeduplicatorTests.java
@@ -64,7 +64,7 @@ class EventDeduplicatorTests {
     private static final long TEST_EVENT_COUNT = 1000;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         random = getRandomPrintSeed();
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/linking/InOrderLinkerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/linking/InOrderLinkerTests.java
@@ -101,7 +101,7 @@ class InOrderLinkerTests {
      * This method creates 2 genesis events and submits them to the linker, as a foundation for the tests.
      */
     @BeforeEach
-    void setup() {
+    void setUp() {
         random = getRandomPrintSeed();
 
         exitedIntakePipelineCount = new AtomicLong(0);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/orphan/OrphanBufferTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/orphan/OrphanBufferTests.java
@@ -220,7 +220,7 @@ class OrphanBufferTests {
     }
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         random = getRandomPrintSeed();
 
         final ArrayList<EventDescriptor> parentCandidates = new ArrayList<>();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/EventSignatureValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/EventSignatureValidatorTests.java
@@ -121,7 +121,7 @@ class EventSignatureValidatorTests {
     }
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         random = getRandomPrintSeed();
         platformContext = TestPlatformContextBuilder.create().build();
         time = new FakeTime();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/InternalEventValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/InternalEventValidatorTests.java
@@ -53,7 +53,7 @@ class InternalEventValidatorTests {
     private InternalEventValidator singleNodeValidator;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         random = getRandomPrintSeed();
 
         exitedIntakePipelineCount = new AtomicLong(0);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/AbstractEventHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/AbstractEventHandlerTests.java
@@ -52,7 +52,7 @@ public abstract class AbstractEventHandlerTests {
     protected Supplier<Instant> consEstimateSupplier;
     protected Random random;
 
-    protected void setup() {
+    protected void setUp() {
         selfId = new NodeId(0L);
         metrics = new NoOpMetrics();
         ssStats = mock(SwirldStateMetrics.class);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/ConsensusQueueTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/ConsensusQueueTests.java
@@ -62,7 +62,7 @@ class ConsensusQueueTests {
     }
 
     @BeforeEach
-    public void setup() {
+    public void setUp() {
         queueThread = new QueueThreadConfiguration<ConsensusRound>(getStaticThreadManager())
                 .setQueue(newQueue())
                 .setNodeId(SELF_ID)

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/ConsensusRoundHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/ConsensusRoundHandlerTests.java
@@ -74,7 +74,7 @@ class ConsensusRoundHandlerTests extends AbstractEventHandlerTests {
 
     @Override
     @BeforeEach
-    public void setup() {
+    public void setUp() {
         super.setup();
         eventStreamManager = mock(EventStreamManager.class);
         stateHashSignQueue = mock(QueueThread.class);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/ConsensusRoundHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/ConsensusRoundHandlerTests.java
@@ -75,7 +75,7 @@ class ConsensusRoundHandlerTests extends AbstractEventHandlerTests {
     @Override
     @BeforeEach
     public void setUp() {
-        super.setup();
+        super.setUp();
         eventStreamManager = mock(EventStreamManager.class);
         stateHashSignQueue = mock(QueueThread.class);
     }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/PreConsensusEventHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/PreConsensusEventHandlerTests.java
@@ -54,7 +54,7 @@ class PreConsensusEventHandlerTests extends AbstractEventHandlerTests {
     @Override
     @BeforeEach
     public void setUp() {
-        super.setup();
+        super.setUp();
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/PreConsensusEventHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/PreConsensusEventHandlerTests.java
@@ -53,7 +53,7 @@ class PreConsensusEventHandlerTests extends AbstractEventHandlerTests {
 
     @Override
     @BeforeEach
-    public void setup() {
+    public void setUp() {
         super.setup();
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/gossip/DefaultIntakeEventCounterTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/gossip/DefaultIntakeEventCounterTests.java
@@ -36,7 +36,7 @@ class DefaultIntakeEventCounterTests {
     final NodeId nodeId2 = new NodeId(2);
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         final AddressBook addressBook = mock(AddressBook.class);
         Mockito.when(addressBook.getNodeIdSet()).thenReturn(Set.of(nodeId1, nodeId2));
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/heartbeat/HeartbeatProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/heartbeat/HeartbeatProtocolTests.java
@@ -51,7 +51,7 @@ class HeartbeatProtocolTests {
     private final int ackDelayMillis = 33;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         peerId = new NodeId(1);
         heartbeatPeriod = Duration.ofMillis(1000);
         networkMetrics = mock(NetworkMetrics.class);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
@@ -127,7 +127,7 @@ class ReconnectProtocolTests {
     }
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         activeStatusGetter = mock(PlatformStatusGetter.class);
         when(activeStatusGetter.getCurrentStatus()).thenReturn(PlatformStatus.ACTIVE);
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencyReconnectTests.java
@@ -98,7 +98,7 @@ class EmergencyReconnectTests {
     private final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
 
     @BeforeEach
-    public void setup() throws ExecutionException, InterruptedException, ConstructableRegistryException {
+    public void setUp() throws ExecutionException, InterruptedException, ConstructableRegistryException {
         ConstructableRegistry.getInstance().registerConstructables("");
 
         when(trueFuture.get()).thenReturn(true);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencySignedStateValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/emergency/EmergencySignedStateValidatorTests.java
@@ -49,7 +49,7 @@ public class EmergencySignedStateValidatorTests {
     private EmergencySignedStateValidator validator;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         addressBook = new RandomAddressBookGenerator()
                 .setSize(NUM_NODES)
                 .setAverageWeight(WEIGHT_PER_NODE)

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
@@ -43,7 +43,7 @@ class SwirldStateManagerTests {
     private State initialState;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         final SwirldsPlatform platform = mock(SwirldsPlatform.class);
         final AddressBook addressBook = new RandomAddressBookGenerator().build();
         when(platform.getAddressBook()).thenReturn(addressBook);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerUtilsTests.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 public class SwirldStateManagerUtilsTests {
 
     @BeforeEach
-    void setup() {}
+    void setUp() {}
 
     @Test
     void testFastCopyIsMutable() {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/TransactionHandlerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/TransactionHandlerTest.java
@@ -57,7 +57,7 @@ class TransactionHandlerTest {
     private TransactionHandler handler;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         when(state.getSwirldDualState()).thenReturn(dualState);
 
         handler = new TransactionHandler(selfId, mock(SwirldStateMetrics.class));

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/sync/protocol/SyncProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/sync/protocol/SyncProtocolTests.java
@@ -63,7 +63,7 @@ class SyncProtocolTests {
     private PlatformContext platformContext;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         peerId = new NodeId(1);
         shadowGraphSynchronizer = mock(ShadowGraphSynchronizer.class);
         fallenBehindManager = mock(FallenBehindManager.class);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/EventStreamSigningUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/EventStreamSigningUtilsTests.java
@@ -75,7 +75,7 @@ class EventStreamSigningUtilsTests {
      * Sets up for each test
      */
     @BeforeEach
-    void setup() {
+    void setUp() {
         destinationDirectory = testDirectoryPath.resolve("signatureFiles");
 
         // the utility method being leveraged saves stream files to a directory "events_test"

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/PlatformStateTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/PlatformStateTests.java
@@ -49,7 +49,7 @@ class PlatformStateTests {
     Path testDirectory;
 
     @BeforeAll
-    public static void setup() throws FileNotFoundException, ConstructableRegistryException {
+    public static void setUp() throws FileNotFoundException, ConstructableRegistryException {
         new TestConfigBuilder().getOrCreateConfig();
     }
 

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/ChatterSyncTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/chatter/ChatterSyncTest.java
@@ -60,7 +60,7 @@ class ChatterSyncTest {
     }
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         resetFallenBehind();
         state.reset();
     }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/EventUtilsTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/EventUtilsTests.java
@@ -44,7 +44,7 @@ class EventUtilsTests {
     private final EventImpl gen7 = mock(EventImpl.class);
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         when(gen1.getGeneration()).thenReturn(1L);
         when(gen2.getGeneration()).thenReturn(2L);
         when(gen3.getGeneration()).thenReturn(3L);

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/GossipEventTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/GossipEventTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 class GossipEventTest {
 
     @BeforeAll
-    public static void setup() throws FileNotFoundException, ConstructableRegistryException {
+    public static void setUp() throws FileNotFoundException, ConstructableRegistryException {
         new TestConfigBuilder().getOrCreateConfig();
     }
 

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/handshake/HashHandshakeTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/handshake/HashHandshakeTests.java
@@ -57,7 +57,7 @@ class HashHandshakeTests {
     }
 
     @BeforeEach
-    void setup() throws ConstructableRegistryException, IOException {
+    void setUp() throws ConstructableRegistryException, IOException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructable(new ClassConstructorPair(Hash.class, Hash::new));
         registry.registerConstructable(new ClassConstructorPair(SerializableLong.class, SerializableLong::new));

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/handshake/VersionHandshakeTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/handshake/VersionHandshakeTests.java
@@ -60,7 +60,7 @@ class VersionHandshakeTests {
     }
 
     @BeforeEach
-    void setup() throws ConstructableRegistryException, IOException {
+    void setUp() throws ConstructableRegistryException, IOException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructable(new ClassConstructorPair(BasicSoftwareVersion.class, BasicSoftwareVersion::new));
         registry.registerConstructable(new ClassConstructorPair(SerializableLong.class, SerializableLong::new));

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/ShadowGraphTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/ShadowGraphTest.java
@@ -88,7 +88,7 @@ class ShadowGraphTest {
     }
 
     @BeforeEach
-    public void setup() {
+    public void setUp() {
         ancestorsMap = new HashMap<>();
         generatedEvents = new ArrayList<>();
         genToShadows = new HashMap<>();

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncTests.java
@@ -215,7 +215,7 @@ public class SyncTests {
     }
 
     @BeforeAll
-    public static void setup() throws FileNotFoundException, ConstructableRegistryException {
+    public static void setUp() throws FileNotFoundException, ConstructableRegistryException {
         new TestConfigBuilder().getOrCreateConfig();
 
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds");

--- a/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapEntryKeyTests.java
+++ b/platform-sdk/swirlds-unit-tests/structures/swirlds-merkle-test/src/test/java/com/swirlds/merkle/map/test/MerkleMapEntryKeyTests.java
@@ -51,7 +51,7 @@ class MerkleMapEntryKeyTests {
     Path testDirectory;
 
     @BeforeAll
-    static void setup() throws ConstructableRegistryException {
+    static void setUp() throws ConstructableRegistryException {
         ConstructableRegistry.getInstance().registerConstructables("*");
     }
 

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualMerkleNavigationTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/VirtualMerkleNavigationTest.java
@@ -67,7 +67,7 @@ class VirtualMerkleNavigationTest extends VirtualTestBase {
     private TestLeaf trlr;
 
     @BeforeEach
-    public void setup() {
+    public void setUp() {
         vm = createMap();
         vm.put(A_KEY, APPLE);
         vm.put(B_KEY, BANANA);


### PR DESCRIPTION
**Description**:

Some function names can be improved for greater readability and maintainability.

This PR changes the following:
* Rename all methods `setup()` in tests to `setUp()` to make it more consistent across entire project

**Related issue(s)**:
Closes #### 